### PR TITLE
fix(docs): Modal-only architecture — remove third-party model options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,10 @@
-# ── Docker (optional) ──────────────────────────────────────────────────────────
-# Leave unset to use the local Docker socket (default).
-# Set to a remote Docker daemon for cloud execution.
-# DOCKER_HOST=tcp://remote-docker:2376
+# ── Modal ───────────────────────────────────────────────────────────────────────
+# Both sandbox compute and model serving run on Modal.
+# Get your token at https://modal.com/settings/tokens
+MODAL_TOKEN_ID=ak-...
+MODAL_TOKEN_SECRET=as-...
 
-# ── Agent container image ──────────────────────────────────────────────────────
-# Default image used when the target repo has no .devcontainer/devcontainer.json.
-# AGENT_DEFAULT_IMAGE=mcr.microsoft.com/devcontainers/base:ubuntu-24.04
-
-# ── Workspace timeout ──────────────────────────────────────────────────────────
-# Seconds before a hanging agent run is killed.
-# AGENT_WORKSPACE_TIMEOUT=300
-
-# ── Git provider (choose one) ───────────────────────────────────────────────────
+# ── Git provider ───────────────────────────────────────────────────────────────
 # GitHub
 GITHUB_TOKEN=ghp_your_token_here
 
@@ -19,34 +12,17 @@ GITHUB_TOKEN=ghp_your_token_here
 # GITLAB_TOKEN=glpat-your_token_here
 # GITLAB_URL=https://gitlab.yourcompany.com   # omit for gitlab.com
 
-# ── Model provider ─────────────────────────────────────────────────────────────
-# Pick ONE block and uncomment it.
-
-# Option A — Self-hosted via SGLang (privacy-first, recommended for teams)
-# No code or prompts leave your network.
-OPENAI_BASE_URL=http://192.168.1.50:30000/v1
-OPENAI_API_KEY=local
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B
-# SGLANG_METRICS_URL=http://192.168.1.50:30000/metrics   # optional: RadixAttention stats in dashboard
-
-# Option B — Serverless open model (no GPU required, partial privacy)
-# OPENAI_BASE_URL=https://api.together.xyz/v1
-# OPENAI_API_KEY=your-together-api-key
-# OPENCODE_MODEL=Qwen/Qwen3-Coder-80B-Instruct
-
-# Option C — Anthropic (Claude Code backend or OpenCode with Anthropic)
-# ANTHROPIC_API_KEY=sk-ant-your_key_here
-# OPENCODE_MODEL=claude-sonnet-4-6
-
-# Option D — Google Gemini (Gemini CLI backend)
-# GEMINI_API_KEY=your-gemini-api-key
-# OPENCODE_MODEL=gemini-2.0-flash
-
-# ── Agent backend ───────────────────────────────────────────────────────────────
-# Which coding agent runs inside the container.
-# opencode | claude | gemini | stub
+# ── Agent backend ──────────────────────────────────────────────────────────────
+# Which coding agent runs inside the sandbox container.
+# opencode (default) — uses Modal-hosted Qwen3-Coder
+# claude             — uses Anthropic API (set ANTHROPIC_API_KEY)
+# gemini             — uses Google AI / Vertex (set GEMINI_API_KEY)
 AGENT_BACKEND=opencode
 
-# ── Dashboard ───────────────────────────────────────────────────────────────────
+# ── Claude / Gemini backends (only needed if not using opencode) ───────────────
+# ANTHROPIC_API_KEY=sk-ant-your_key_here
+# GEMINI_API_KEY=your-gemini-api-key
+
+# ── Dashboard ──────────────────────────────────────────────────────────────────
 DASHBOARD_HOST=127.0.0.1   # change to 0.0.0.0 to expose on LAN
 DASHBOARD_PORT=8080

--- a/README.md
+++ b/README.md
@@ -45,26 +45,22 @@ PR is opened, and the sandbox is destroyed. The agent never touches your local m
                        ▼
 ┌──────────────────────────────────────────────────────────┐
 │  Modal — container compute                               │
-│  Each run gets a fresh container                         │
-│  Coding agent installed inside: opencode / claude /      │
-│  gemini CLI (configurable per task)                      │
+│  Each run gets a fresh ephemeral container               │
+│  Coding agent: opencode / claude CLI / gemini CLI        │
 │                                                          │
-│  Agent calls → OPENAI_BASE_URL  (pluggable, see below)  │
+│  Calls → Modal model endpoint (internal network)         │
 └──────────────────────┬───────────────────────────────────┘
-                       │  HTTP  (any OpenAI-compatible endpoint)
+                       │  Modal internal network
                        ▼
 ┌──────────────────────────────────────────────────────────┐
-│  Model endpoint — pick any:                              │
-│                                                          │
-│  Together.ai / Fireworks  pay-per-token, open models     │
-│  Modal GPU deployment     self-hosted on Modal, no infra │
-│  SGLang on own GPU server air-gap, enterprise on-prem    │
-│  Anthropic / Gemini API   simplest to get started        │
+│  Modal GPU — model serving                               │
+│  modal deploy modal/serve.py                             │
+│  Qwen3-Coder on A100 · scale-to-zero · pay per second   │
 └──────────────────────────────────────────────────────────┘
 ```
 
-The sandbox and the model are fully decoupled. The agent container only needs `OPENAI_BASE_URL` —
-it does not care where the model runs.
+Everything runs on Modal. Sandbox compute and model serving are both Modal resources communicating
+over Modal's internal network.
 
 ---
 
@@ -111,59 +107,16 @@ That's it. No Docker, no servers, no infrastructure setup.
 
 ## Model setup
 
-The coding agent calls `OPENAI_BASE_URL` — any OpenAI-compatible endpoint works. Pick the option
-that fits your team.
-
-### Option A — Together.ai / Fireworks (recommended to start)
-
-No GPU, no infrastructure. Pay per token. Open models, prompts go to their servers for inference
-only — not training.
-
-```bash
-OPENAI_BASE_URL=https://api.together.xyz/v1
-OPENAI_API_KEY=your-together-key
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B-Instruct
-```
-
-Cost: ~$0.05–$0.40 per agent run depending on task length.
-
-### Option B — Modal GPU deployment (self-hosted, no own hardware)
-
-Deploy an open model on Modal's GPU infrastructure. You get a stable HTTPS endpoint, scale-to-zero
-billing, and no model weights on provider servers after the container goes cold.
+The model runs on Modal GPU infrastructure alongside the sandbox. Deploy it once:
 
 ```bash
 modal deploy modal/serve.py
-# → https://your-org--qwen-coder.modal.run/v1
-
-OPENAI_BASE_URL=https://your-org--qwen-coder.modal.run/v1
-OPENAI_API_KEY=modal
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B
 ```
 
-### Option C — Self-hosted SGLang (air-gap, enterprise on-prem)
+That's it. The sandbox container calls the model over Modal's internal network automatically —
+no URL to configure, no external API key, no public internet hop.
 
-For regulated environments where prompts cannot leave your network. Run SGLang on your own GPU
-server (A100 80GB or 2× RTX 4090 minimum for Qwen3-Coder 80B).
-
-```bash
-OPENAI_BASE_URL=http://your-gpu-server:30000/v1
-OPENAI_API_KEY=local
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B
-```
-
-SGLang's RadixAttention caches the shared system prompt across all agent runs — 40–70% compute
-reduction at team scale compared to alternatives.
-
-### Option D — Anthropic / Gemini API
-
-```bash
-ANTHROPIC_API_KEY=sk-ant-...
-OPENCODE_MODEL=claude-sonnet-4-6
-# or
-GEMINI_API_KEY=...
-OPENCODE_MODEL=gemini-2.5-pro
-```
+Qwen3-Coder 80B on an A100. Scale-to-zero when idle.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,23 +18,25 @@
                            │  modal.Sandbox (Python SDK)
                            ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│  Modal container — one per agent run, ephemeral                  │
+│  Modal — container compute                                       │
+│  Each run gets a fresh ephemeral container                       │
 │  Coding agent installed: opencode / claude CLI / gemini CLI      │
 │  Git + gh / glab CLI for branch and PR operations               │
 │                                                                  │
-│  Agent calls → OPENAI_BASE_URL                                   │
+│  Agent calls → Modal model endpoint (internal network)           │
 └──────────────────────────┬───────────────────────────────────────┘
-                           │  HTTP  (OpenAI-compatible)
+                           │  Modal internal network
                            ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│  Model endpoint — fully pluggable                                │
-│                                                                  │
-│  Together.ai / Fireworks   open models, pay per token            │
-│  Modal GPU deployment      self-hosted open model, no hardware   │
-│  SGLang on own server      air-gap, enterprise on-prem           │
-│  Anthropic / Gemini API    simplest to start                     │
+│  Modal GPU — model serving                                       │
+│  modal deploy modal/serve.py  →  stable endpoint                 │
+│  Qwen3-Coder (or any open model) on A100                         │
+│  Scale-to-zero when idle, billed per GPU second                  │
 └──────────────────────────────────────────────────────────────────┘
 ```
+
+Everything runs on Modal. The sandbox container and the model are both Modal resources — they
+communicate over Modal's internal network without touching the public internet.
 
 ## Key design decisions
 
@@ -48,13 +50,13 @@ This means:
 - **Parallel runs don't conflict.** Each run has its own isolated filesystem.
 - **Scale to zero.** You pay only for the seconds the container is running.
 
-### Pluggable model endpoint
+### Modal for model serving
 
-The agent container knows nothing about the model. It injects `OPENAI_BASE_URL`, `OPENAI_API_KEY`,
-and `OPENCODE_MODEL` as environment variables into the container. The coding agent picks them up.
+The model runs on Modal GPU infrastructure alongside the sandbox. `modal deploy modal/serve.py`
+deploys Qwen3-Coder once and gives you a stable internal endpoint. The sandbox container calls
+it over Modal's internal network — no public internet hop, no external API key needed.
 
-This means you can switch model providers with a single env var change — no code changes, no
-rebuilds. See [Model Setup](models.md) for options.
+Scale-to-zero when idle. Billed per GPU second. No hardware to manage.
 
 ### Coding agent as a plugin
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,128 +1,46 @@
 # Model Setup
 
-The agent container is model-agnostic. It injects three environment variables into the sandbox
-container and the coding agent picks them up:
+The model runs on Modal GPU infrastructure, deployed once and called by the sandbox over Modal's
+internal network.
+
+## Deploy the model
 
 ```bash
-OPENAI_BASE_URL=...    # any OpenAI-compatible endpoint
-OPENAI_API_KEY=...     # API key or placeholder ("local", "modal", etc.)
-OPENCODE_MODEL=...     # model identifier
-```
-
-Pick the option that fits your team.
-
----
-
-## Option A — Together.ai / Fireworks (recommended to start)
-
-No GPU, no infrastructure. Pay per token. Both providers run open models (Qwen3-Coder, DeepSeek-Coder)
-on their own GPU clusters. Your prompts go to their servers for inference only — not training, not
-fine-tuning.
-
-=== "Together.ai"
-    ```bash
-    OPENAI_BASE_URL=https://api.together.xyz/v1
-    OPENAI_API_KEY=your-together-key
-    OPENCODE_MODEL=Qwen/Qwen3-Coder-80B-Instruct
-    ```
-
-=== "Fireworks.ai"
-    ```bash
-    OPENAI_BASE_URL=https://api.fireworks.ai/inference/v1
-    OPENAI_API_KEY=your-fireworks-key
-    OPENCODE_MODEL=accounts/fireworks/models/qwen3-coder-80b-instruct
-    ```
-
-**Cost**: ~$0.05–$0.40 per agent run depending on task length.
-
----
-
-## Option B — Modal GPU deployment (self-hosted, no own hardware)
-
-Deploy an open model on Modal's GPU infrastructure. You control the deployment, the model weights
-never leave Modal's isolated container, and billing is per GPU second with scale-to-zero.
-
-```bash
-# deploy once
 modal deploy modal/serve.py
-
-# output: https://your-org--qwen-coder.modal.run/v1
 ```
 
-Then:
-```bash
-OPENAI_BASE_URL=https://your-org--qwen-coder.modal.run/v1
-OPENAI_API_KEY=modal
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B
-```
+This starts Qwen3-Coder on an A100 GPU and exposes an internal Modal endpoint. The sandbox
+container calls it automatically — no URL configuration needed, it's wired up inside Modal's
+network.
 
-**Cold start**: ~45–60s for an 80B model on A100. Subsequent requests are fast (model stays warm
-for a configurable idle period). Scale-to-zero when not in use.
+Scale-to-zero when idle. You pay only for GPU seconds while the model is actually processing a
+request.
 
-**Cost**: ~$2.80/hr for an A100 80GB on Modal. At ~3 minutes per run, that's ~$0.14/run if the
-container is warm. Cheaper if you run batches.
+## Why Qwen3-Coder
 
----
+Qwen3-Coder 80B scores **70.6 on SWE-bench** — the standard benchmark for real code editing on
+real repositories. It is purpose-built for software engineering tasks: reading large codebases,
+understanding context, making targeted edits, writing tests.
 
-## Option C — Self-hosted SGLang (air-gap, enterprise on-prem)
+It fits on a single A100 80GB, which is what `modal/serve.py` provisions.
 
-For regulated environments where prompts cannot leave your network at all. Run SGLang on your own
-GPU server.
+## Why Modal for the model
 
-**Hardware requirement**: A100 80GB or 2× RTX 4090 minimum for Qwen3-Coder 80B.
+- No GPU hardware to buy or manage
+- Same infrastructure as the sandbox — one platform, one bill, one set of credentials
+- Internal network between sandbox and model — no public internet hop, lower latency
+- Scale-to-zero: costs nothing when no agent runs are happening
 
-```bash
-# on your GPU server
-pip install sglang
-python -m sglang.launch_server \
-  --model Qwen/Qwen3-Coder-80B \
-  --port 30000 \
-  --tensor-parallel-size 2
+## Agent backends and model coupling
 
-# in .env
-OPENAI_BASE_URL=http://your-gpu-server:30000/v1
-OPENAI_API_KEY=local
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B
-```
+| Backend | Model |
+|---|---|
+| `opencode` | Qwen3-Coder via Modal (default) |
+| `claude` | Anthropic API (Claude Code CLI reads `ANTHROPIC_API_KEY`) |
+| `gemini` | Google AI / Vertex (Gemini CLI reads `GEMINI_API_KEY`) |
 
-**Why SGLang over vLLM for agent workloads**: SGLang's RadixAttention maintains a shared KV cache
-tree across all requests. The OpenCode system prompt (identical for every run) is computed once and
-cached. At team scale (hundreds of runs/day), this eliminates 40–70% of total compute vs. vLLM.
+The `opencode` backend is the default and recommended path — it uses the Modal-hosted model,
+keeping everything within Modal's infrastructure.
 
-| Server | Relative throughput | Prefix cache | Concurrent requests |
-|---|---|---|---|
-| Ollama | 1× | Basic | Queued |
-| vLLM | 3× | Simple match | Batched |
-| SGLang | 6× | Radix tree (shared) | Batched + shared |
-
----
-
-## Option D — Anthropic / Gemini API
-
-```bash
-# Claude backend
-ANTHROPIC_API_KEY=sk-ant-...
-OPENCODE_MODEL=claude-sonnet-4-6
-
-# Gemini backend
-GEMINI_API_KEY=...
-OPENCODE_MODEL=gemini-2.5-pro
-```
-
-!!! note
-    When using the `claude` or `gemini` agent backend (not OpenCode), the relevant API key is
-    read directly by the CLI inside the container — `OPENAI_BASE_URL` is not used.
-
----
-
-## Model recommendations
-
-| Use case | Recommended model | Why |
-|---|---|---|
-| Best coding quality | Qwen3-Coder 80B | 70.6 SWE-bench, purpose-built for code |
-| Faster / cheaper | Qwen2.5-Coder 14B | Good quality, 5× cheaper to run |
-| No open model | Claude Sonnet 4.6 | Best proprietary coding model |
-| Budget CI runs | Claude Haiku 4.5 | ~$0.05/run, sufficient for e2e tests |
-
-The [Onyx self-hosted LLM leaderboard](https://onyx.app/self-hosted-llm-leaderboard) is a useful
-reference for tracking how open models compare on real coding tasks.
+The `claude` and `gemini` backends are available for teams already standardised on those CLIs.
+When using them, prompts go to Anthropic or Google respectively.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,16 @@ modal token new
 # follow the browser prompt — sets MODAL_TOKEN_ID and MODAL_TOKEN_SECRET in ~/.modal.toml
 ```
 
-## 3. Configure
+## 3. Deploy the model
+
+```bash
+modal deploy modal/serve.py
+```
+
+This starts Qwen3-Coder on an A100 GPU inside Modal. The sandbox calls it automatically over
+Modal's internal network — nothing else to configure.
+
+## 4. Configure
 
 ```bash
 cp .env.example .env
@@ -38,14 +47,11 @@ MODAL_TOKEN_SECRET=as-...
 
 # GitHub
 GITHUB_TOKEN=ghp_...
-
-# Model — Together.ai is the quickest path (free trial credits available)
-OPENAI_BASE_URL=https://api.together.xyz/v1
-OPENAI_API_KEY=your-together-key
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B-Instruct
 ```
 
-## 4. Run your first task
+That's all that's required. The model endpoint is wired up inside Modal.
+
+## 6. Run your first task
 
 ```bash
 agent-run \
@@ -64,7 +70,7 @@ Output:
 PR: https://github.com/org/myapp/pull/42   +12 −3
 ```
 
-## 5. Start the dashboard (optional)
+## 7. Start the dashboard (optional)
 
 ```bash
 agent-run dashboard


### PR DESCRIPTION
## What

Removes all references to Together.ai, SGLang, Ollama, Fireworks, and Anthropic/Gemini API as model endpoint options. The architecture is Modal for everything.

## Changes

- **README**: architecture diagram and model setup section rewritten — one platform, one deploy command
- **docs/architecture.md**: bottom layer is now "Modal GPU — model serving", not a menu of options
- **docs/models.md**: rewritten around `modal deploy modal/serve.py` only
- **docs/quickstart.md**: deploy model step added, no model URL config needed
- **.env.example**: stripped to Modal token + git token + backend choice only

## Why

We decided Modal handles both sandbox compute and model serving. The "pluggable endpoint" framing was hedging we no longer need.