### PR TITLE
feat(sandbox): ModalSandbox — ephemeral Modal containers for agent runs

### DIFF
--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,6 +1,6 @@
 from .config import ConfigError, SandboxConfig
 from .result import AgentTaskResult, SuiteResult
-from .sandbox import DevContainerSandbox
+from .sandbox import ModalSandbox
 from .spec import AgentTaskSpec
 
 __all__ = [
@@ -9,5 +9,5 @@ __all__ = [
     "AgentTaskSpec",
     "AgentTaskResult",
     "SuiteResult",
-    "DevContainerSandbox",
+    "ModalSandbox",
 ]

--- a/sandbox/config.py
+++ b/sandbox/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,7 +9,7 @@ from dotenv import load_dotenv
 
 
 class ConfigError(Exception):
-    """Raised when required tooling is missing or Docker is unreachable."""
+    """Raised when required configuration is missing or Modal is unreachable."""
 
 
 _DEFAULT_IMAGE = "mcr.microsoft.com/devcontainers/base:ubuntu-24.04"
@@ -18,7 +17,6 @@ _DEFAULT_IMAGE = "mcr.microsoft.com/devcontainers/base:ubuntu-24.04"
 
 @dataclass
 class SandboxConfig:
-    docker_host: str = ""  # empty → use default local socket
     default_image: str = _DEFAULT_IMAGE
     workspace_timeout_seconds: int = 300
 
@@ -28,44 +26,33 @@ class SandboxConfig:
         load_dotenv(env_file or Path(".env"), override=False)
 
         return cls(
-            docker_host=os.getenv("DOCKER_HOST", "").strip(),
             default_image=os.getenv("AGENT_DEFAULT_IMAGE", _DEFAULT_IMAGE).strip(),
             workspace_timeout_seconds=int(os.getenv("AGENT_WORKSPACE_TIMEOUT", "300").strip()),
         )
 
     def validate_connection(self) -> None:
-        """Check devcontainer CLI is installed and Docker daemon is running."""
-        self._require_devcontainer_cli()
-        self._require_docker()
+        """Check Modal CLI is installed and the current token is valid."""
+        self._require_modal_cli()
+        self._require_modal_auth()
 
-    def _require_devcontainer_cli(self) -> None:
-        if shutil.which("devcontainer"):
-            return
-        # Fall back to npx — installs on first use, acceptable for CI
+    def _require_modal_cli(self) -> None:
         result = subprocess.run(
-            ["npx", "--yes", "@devcontainers/cli", "--version"],
+            ["modal", "--version"],
             capture_output=True,
-            timeout=60,
+            timeout=10,
         )
         if result.returncode != 0:
-            raise ConfigError(
-                "devcontainer CLI not found.\n"
-                "Install it with: npm install -g @devcontainers/cli\n"
-                "Or ensure Node.js / npx is on PATH."
-            )
+            raise ConfigError("modal CLI not found.\nInstall it with: pip install modal")
 
-    def _require_docker(self) -> None:
-        env = {**os.environ}
-        if self.docker_host:
-            env["DOCKER_HOST"] = self.docker_host
+    def _require_modal_auth(self) -> None:
         result = subprocess.run(
-            ["docker", "info"],
+            ["modal", "token", "current"],
             capture_output=True,
-            env=env,
             timeout=10,
         )
         if result.returncode != 0:
             raise ConfigError(
-                "Docker daemon is not running or not reachable.\n"
-                "Start Docker Desktop or 'sudo systemctl start docker'."
+                "Modal token not configured.\n"
+                "Run: modal token new\n"
+                "Or set MODAL_TOKEN_ID and MODAL_TOKEN_SECRET in .env"
             )

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -1,44 +1,38 @@
-"""DevContainer-based agent sandbox: boot → exec → teardown."""
+"""Modal-based agent sandbox: boot → exec → teardown."""
 
 from __future__ import annotations
 
 import shlex
-import shutil
-import subprocess
-import tempfile
 import time
-from pathlib import Path
+
+import modal
 
 from sandbox.config import ConfigError, SandboxConfig
 from sandbox.result import AgentTaskResult
 from sandbox.spec import AgentTaskSpec
 
-# Name given to our fallback devcontainer spec inside a workspace that
-# doesn't already ship a .devcontainer directory.
-_DEVCONTAINER_DIR = ".devcontainer"
-_DEVCONTAINER_JSON = "devcontainer.json"
-
-# Source of the project-level default spec (relative to this file's package root)
-_DEFAULT_SPEC = Path(__file__).parent.parent / _DEVCONTAINER_DIR / _DEVCONTAINER_JSON
-
-
-def _devcontainer_bin() -> list[str]:
-    """Return the argv prefix for the devcontainer CLI."""
-    if shutil.which("devcontainer"):
-        return ["devcontainer"]
-    return ["npx", "--yes", "@devcontainers/cli"]
+# Base image — git + Node (for opencode) + Python pre-installed.
+# Built once by Modal and cached; subsequent runs reuse the cached layer.
+_BASE_IMAGE = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git", "curl")
+    .run_commands(
+        "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -",
+        "apt-get install -y nodejs",
+        "npm install -g opencode-ai",
+    )
+)
 
 
-class DevContainerSandbox:
-    """Run an agent task inside an ephemeral dev container.
+class ModalSandbox:
+    """Run an agent task inside an ephemeral Modal sandbox.
 
     Lifecycle per call to :meth:`run`:
-      1. Clone repo into a temporary directory
-      2. Ensure ``.devcontainer/devcontainer.json`` exists (copy default if absent)
-      3. ``devcontainer up``  — build image + start container
-      4. ``devcontainer exec`` — run the coding agent
-      5. Collect ``git diff`` output
-      6. ``devcontainer down`` — stop + remove container (always, even on failure)
+      1. Create a Modal sandbox with the configured image
+      2. Clone the target repo inside the sandbox
+      3. Run the coding agent (opencode / claude / gemini / stub)
+      4. Collect ``git diff`` output
+      5. Terminate the sandbox (always, even on failure)
     """
 
     def __init__(self, config: SandboxConfig) -> None:
@@ -48,33 +42,29 @@ class DevContainerSandbox:
 
     def run(self, spec: AgentTaskSpec) -> AgentTaskResult:
         start = time.monotonic()
-        tmpdir = tempfile.mkdtemp(prefix="agent-sandbox-")
-        workspace = Path(tmpdir)
+        sb: modal.Sandbox | None = None
         try:
-            self._clone(spec, workspace)
-            self._ensure_devcontainer(workspace, spec)
-            self._up(workspace)
-            try:
-                agent_output, exit_code = self._exec_agent(workspace, spec)
-                diff, diff_stat = self._collect_diff(workspace)
-            finally:
-                self._down(workspace)
+            sb = self._create(spec)
+            self._clone(sb, spec)
+            agent_output, exit_code = self._exec_agent(sb, spec)
+            diff, diff_stat = self._collect_diff(sb)
         except Exception as exc:
             duration = time.monotonic() - start
+            _terminate(sb)
             return AgentTaskResult(
                 success=False,
-                run_id=workspace.name,
+                run_id=_run_id(sb),
                 duration_seconds=duration,
                 error=str(exc),
                 backend=spec.backend,
             )
-        finally:
-            _rmtree(workspace)
 
+        _terminate(sb)
         duration = time.monotonic() - start
+
         return AgentTaskResult(
             success=exit_code == 0,
-            run_id=workspace.name,
+            run_id=_run_id(sb),
             diff=diff,
             diff_stat=diff_stat,
             duration_seconds=duration,
@@ -84,87 +74,55 @@ class DevContainerSandbox:
 
     # ----------------------------------------------------------------- private
 
-    def _clone(self, spec: AgentTaskSpec, workspace: Path) -> None:
-        _run(
-            [
-                "git",
-                "clone",
-                "--branch",
-                spec.base_branch,
-                "--depth",
-                "1",
-                spec.repo,
-                str(workspace),
-            ],
-            timeout=120,
-            error_prefix="git clone failed",
-        )
-
-    def _ensure_devcontainer(self, workspace: Path, spec: AgentTaskSpec) -> None:
-        dc_dir = workspace / _DEVCONTAINER_DIR
-        if (dc_dir / _DEVCONTAINER_JSON).exists():
-            return  # repo ships its own spec — use it as-is
-        dc_dir.mkdir(exist_ok=True)
-        image = spec.resolved_image(self.config.default_image)
-        _write_minimal_spec(dc_dir / _DEVCONTAINER_JSON, image)
-
-    def _up(self, workspace: Path) -> None:
-        _run(
-            [*_devcontainer_bin(), "up", "--workspace-folder", str(workspace)],
-            timeout=300,
-            error_prefix="devcontainer up failed",
-        )
-
-    def _exec_agent(self, workspace: Path, spec: AgentTaskSpec) -> tuple[str, int]:
-        task = spec.resolved_task()
-        cmd = _agent_command(spec.backend, task)
-        result = subprocess.run(
-            [*_devcontainer_bin(), "exec", "--workspace-folder", str(workspace), *cmd],
-            capture_output=True,
-            text=True,
+    def _create(self, spec: AgentTaskSpec) -> modal.Sandbox:
+        image = _BASE_IMAGE
+        if spec.image:
+            image = modal.Image.from_registry(spec.image)
+        return modal.Sandbox.create(
+            image=image,
             timeout=spec.timeout_seconds,
+            secrets=[modal.Secret.from_dict(spec.env)] if spec.env else [],
         )
-        combined = (result.stdout + result.stderr).strip()
-        return combined, result.returncode
 
-    def _collect_diff(self, workspace: Path) -> tuple[str, str]:
-        diff = subprocess.run(
-            ["git", "diff", "HEAD"],
-            cwd=workspace,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        ).stdout
-        stat = subprocess.run(
-            ["git", "diff", "--stat", "HEAD"],
-            cwd=workspace,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        ).stdout
+    def _clone(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> None:
+        proc = sb.exec(
+            "git",
+            "clone",
+            "--branch",
+            spec.base_branch,
+            "--depth",
+            "1",
+            spec.repo,
+            "/workspace",
+        )
+        proc.wait()
+        if proc.returncode != 0:
+            raise ConfigError(f"git clone failed:\n{proc.stderr.read()}")
+
+    def _exec_agent(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> tuple[str, int]:
+        cmd = _agent_command(spec.backend, spec.resolved_task())
+        proc = sb.exec(*cmd, workdir="/workspace")
+        output = proc.stdout.read()
+        proc.wait()
+        return output, proc.returncode
+
+    def _collect_diff(self, sb: modal.Sandbox) -> tuple[str, str]:
+        diff_proc = sb.exec("git", "diff", "HEAD", workdir="/workspace")
+        diff = diff_proc.stdout.read()
+        diff_proc.wait()
+
+        stat_proc = sb.exec("git", "diff", "--stat", "HEAD", workdir="/workspace")
+        stat = stat_proc.stdout.read()
+        stat_proc.wait()
+
         return diff, stat.strip()
-
-    def _down(self, workspace: Path) -> None:
-        # Best-effort: don't let teardown failure mask the real result
-        subprocess.run(
-            [*_devcontainer_bin(), "down", "--workspace-folder", str(workspace)],
-            capture_output=True,
-            timeout=60,
-        )
 
 
 # ------------------------------------------------------------------ helpers
 
 
-def _run(cmd: list[str], *, timeout: int, error_prefix: str) -> None:
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-    if result.returncode != 0:
-        detail = (result.stderr or result.stdout).strip()
-        raise ConfigError(f"{error_prefix}:\n{detail}")
-
-
 def _agent_command(backend: str, task: str) -> list[str]:
-    """Return the argv to run the coding agent inside the container."""
+    """Return the argv to run the coding agent inside the sandbox."""
     if backend == "opencode":
         return ["opencode", "--print", "-m", task]
     if backend == "claude":
@@ -172,20 +130,24 @@ def _agent_command(backend: str, task: str) -> list[str]:
     if backend == "gemini":
         return ["gemini", "--yolo", "-p", task]
     if backend == "stub":
-        # Used in integration tests — echoes the task, exits 0, makes no changes
         return ["sh", "-c", f"echo {shlex.quote(task)}"]
     raise ValueError(f"Unknown backend: {backend!r}")
 
 
-def _write_minimal_spec(path: Path, image: str) -> None:
-    path.write_text(
-        f'{{\n  "name": "agent-sandbox",\n  "image": "{image}"\n}}\n',
-        encoding="utf-8",
-    )
+def _terminate(sb: modal.Sandbox | None) -> None:
+    """Terminate sandbox, ignoring errors (best-effort cleanup)."""
+    if sb is None:
+        return
+    try:
+        sb.terminate()
+    except Exception:  # noqa: S110
+        pass  # best-effort — don't let teardown errors propagate
 
 
-def _rmtree(path: Path) -> None:
-    """Remove a directory tree, ignoring errors (best-effort cleanup)."""
-    import shutil as _shutil
-
-    _shutil.rmtree(path, ignore_errors=True)
+def _run_id(sb: modal.Sandbox | None) -> str:
+    if sb is None:
+        return "unknown"
+    try:
+        return sb.object_id
+    except Exception:  # noqa: S110
+        return "unknown"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,24 +10,20 @@ from sandbox.config import _DEFAULT_IMAGE, ConfigError, SandboxConfig  # noqa: P
 
 class TestSandboxConfigFromEnv:
     def test_default_values(self, monkeypatch):
-        monkeypatch.delenv("DOCKER_HOST", raising=False)
         monkeypatch.delenv("AGENT_DEFAULT_IMAGE", raising=False)
         monkeypatch.delenv("AGENT_WORKSPACE_TIMEOUT", raising=False)
 
         config = SandboxConfig.from_env()
 
-        assert config.docker_host == ""
         assert config.default_image == _DEFAULT_IMAGE
         assert config.workspace_timeout_seconds == 300
 
     def test_overrides_defaults_from_env(self, monkeypatch):
-        monkeypatch.setenv("DOCKER_HOST", "tcp://remote:2376")
         monkeypatch.setenv("AGENT_DEFAULT_IMAGE", "python:3.11-slim")
         monkeypatch.setenv("AGENT_WORKSPACE_TIMEOUT", "600")
 
         config = SandboxConfig.from_env()
 
-        assert config.docker_host == "tcp://remote:2376"
         assert config.default_image == "python:3.11-slim"
         assert config.workspace_timeout_seconds == 600
 
@@ -40,73 +36,44 @@ class TestSandboxConfigFromEnv:
         assert config.default_image == "python:3.11-slim"
         assert config.workspace_timeout_seconds == 120
 
-    def test_docker_host_empty_by_default(self, monkeypatch):
-        monkeypatch.delenv("DOCKER_HOST", raising=False)
-
-        config = SandboxConfig.from_env()
-
-        assert config.docker_host == ""
-
 
 class TestSandboxConfigValidateConnection:
     def _config(self) -> SandboxConfig:
         return SandboxConfig()
 
-    @patch("sandbox.config.shutil.which", return_value="/usr/local/bin/devcontainer")
     @patch("sandbox.config.subprocess.run")
-    def test_passes_when_cli_and_docker_available(self, mock_run, _mock_which):
-        mock_run.return_value = MagicMock(returncode=0)
-
-        # should not raise
-        self._config().validate_connection()
-
-        # only docker info should be called (which() found devcontainer)
-        mock_run.assert_called_once()
-        assert mock_run.call_args[0][0] == ["docker", "info"]
-
-    @patch("sandbox.config.shutil.which", return_value=None)
-    @patch("sandbox.config.subprocess.run")
-    def test_falls_back_to_npx_when_cli_not_on_path(self, mock_run, _mock_which):
-        # npx succeeds, docker info succeeds
+    def test_passes_when_modal_cli_and_auth_available(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
         self._config().validate_connection()
 
+        assert mock_run.call_count == 2
         calls = [c[0][0] for c in mock_run.call_args_list]
-        assert any("npx" in cmd for cmd in calls)
+        assert calls[0] == ["modal", "--version"]
+        assert calls[1] == ["modal", "token", "current"]
 
-    @patch("sandbox.config.shutil.which", return_value=None)
     @patch("sandbox.config.subprocess.run")
-    def test_raises_config_error_when_npx_fails(self, mock_run, _mock_which):
+    def test_raises_when_modal_cli_missing(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1)
 
-        with pytest.raises(ConfigError, match="devcontainer CLI not found"):
+        with pytest.raises(ConfigError, match="modal CLI not found"):
             self._config().validate_connection()
 
-    @patch("sandbox.config.shutil.which", return_value="/usr/local/bin/devcontainer")
     @patch("sandbox.config.subprocess.run")
-    def test_raises_config_error_when_docker_not_running(self, mock_run, _mock_which):
-        mock_run.return_value = MagicMock(returncode=1)
+    def test_raises_when_modal_token_not_configured(self, mock_run):
+        # First call (--version) succeeds, second (token current) fails
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=1),
+        ]
 
-        with pytest.raises(ConfigError, match="Docker daemon"):
+        with pytest.raises(ConfigError, match="Modal token not configured"):
             self._config().validate_connection()
 
-    @patch("sandbox.config.shutil.which", return_value="/usr/local/bin/devcontainer")
-    @patch("sandbox.config.subprocess.run")
-    def test_passes_docker_host_env_when_set(self, mock_run, _mock_which):
-        mock_run.return_value = MagicMock(returncode=0)
-        config = SandboxConfig(docker_host="tcp://remote:2376")
-
-        config.validate_connection()
-
-        docker_call = mock_run.call_args
-        assert docker_call[1]["env"]["DOCKER_HOST"] == "tcp://remote:2376"
-
-    @patch("sandbox.config.shutil.which", return_value="/usr/local/bin/devcontainer")
     @patch(
         "sandbox.config.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=10),
+        side_effect=subprocess.TimeoutExpired(cmd="modal", timeout=10),
     )
-    def test_timeout_on_docker_info_raises_config_error(self, _mock_run, _mock_which):
+    def test_timeout_raises(self, _mock_run):
         with pytest.raises(subprocess.TimeoutExpired):
             self._config().validate_connection()

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,0 +1,211 @@
+"""Unit tests for ModalSandbox — Modal SDK fully mocked, no network required."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox, _agent_command
+from sandbox.spec import AgentTaskSpec
+
+
+def _spec(**kwargs) -> AgentTaskSpec:
+    defaults = dict(repo="https://github.com/org/repo", task="fix it")
+    return AgentTaskSpec(**{**defaults, **kwargs})
+
+
+def _config() -> SandboxConfig:
+    return SandboxConfig()
+
+
+def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout.read.return_value = stdout
+    proc.stderr.read.return_value = ""
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ------------------------------------------------------------------ happy path
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_run_success_returns_result(mock_create):
+    sb = MagicMock()
+    sb.object_id = "sb-abc123"
+    mock_create.return_value = sb
+
+    clone_proc = _make_proc(returncode=0)
+    agent_proc = _make_proc(stdout="done", returncode=0)
+    diff_proc = _make_proc(stdout="diff --git a/f b/f\n+fix")
+    stat_proc = _make_proc(stdout=" 1 file changed")
+
+    sb.exec.side_effect = [clone_proc, agent_proc, diff_proc, stat_proc]
+
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is True
+    assert result.run_id == "sb-abc123"
+    assert result.diff == "diff --git a/f b/f\n+fix"
+    assert result.diff_stat == "1 file changed"
+    assert result.error is None
+    assert result.backend == "opencode"
+    sb.terminate.assert_called_once()
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_run_passes_timeout_to_sandbox(mock_create):
+    sb = MagicMock()
+    mock_create.return_value = sb
+    sb.exec.return_value = _make_proc()
+
+    ModalSandbox(_config()).run(_spec(timeout_seconds=120))
+
+    _, kwargs = mock_create.call_args
+    assert kwargs["timeout"] == 120
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_run_uses_custom_image_when_spec_sets_it(mock_create):
+    sb = MagicMock()
+    mock_create.return_value = sb
+    sb.exec.return_value = _make_proc()
+
+    with patch("sandbox.sandbox.modal.Image.from_registry") as mock_img:
+        mock_img.return_value = MagicMock()
+        ModalSandbox(_config()).run(_spec(image="python:3.11-slim"))
+
+    mock_img.assert_called_once_with("python:3.11-slim")
+
+
+# ------------------------------------------------------------------ failures
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_clone_failure_returns_failed_result(mock_create):
+    sb = MagicMock()
+    sb.object_id = "sb-clone-fail"
+    mock_create.return_value = sb
+
+    clone_proc = _make_proc(returncode=1)
+    clone_proc.stderr.read.return_value = "fatal: repo not found"
+    sb.exec.return_value = clone_proc
+
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is False
+    assert "git clone failed" in result.error
+    sb.terminate.assert_called_once()
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_agent_nonzero_exit_returns_failed_result(mock_create):
+    sb = MagicMock()
+    sb.object_id = "sb-agent-fail"
+    mock_create.return_value = sb
+
+    clone_proc = _make_proc(returncode=0)
+    agent_proc = _make_proc(stdout="something went wrong", returncode=1)
+    diff_proc = _make_proc()
+    stat_proc = _make_proc()
+
+    sb.exec.side_effect = [clone_proc, agent_proc, diff_proc, stat_proc]
+
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is False
+    assert result.error == "something went wrong"
+    sb.terminate.assert_called_once()
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_terminate_called_even_when_exec_raises(mock_create):
+    sb = MagicMock()
+    sb.object_id = "sb-exc"
+    mock_create.return_value = sb
+    sb.exec.side_effect = RuntimeError("connection lost")
+
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is False
+    assert "connection lost" in result.error
+    sb.terminate.assert_called_once()
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_terminate_failure_does_not_mask_result(mock_create):
+    sb = MagicMock()
+    sb.object_id = "sb-term-fail"
+    mock_create.return_value = sb
+    sb.exec.return_value = _make_proc()
+    sb.terminate.side_effect = RuntimeError("terminate failed")
+
+    # should not raise — terminate errors are swallowed
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is True
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create", side_effect=RuntimeError("Modal API error"))
+def test_sandbox_create_failure_returns_failed_result(_mock_create):
+    result = ModalSandbox(_config()).run(_spec())
+
+    assert result.success is False
+    assert "Modal API error" in result.error
+
+
+# ------------------------------------------------------------------ agent commands
+
+
+@pytest.mark.parametrize(
+    "backend, expected_start",
+    [
+        ("opencode", ["opencode", "--print", "-m"]),
+        ("claude", ["claude", "--print"]),
+        ("gemini", ["gemini", "--yolo", "-p"]),
+        ("stub", ["sh", "-c"]),
+    ],
+)
+def test_agent_command_dispatch(backend, expected_start):
+    cmd = _agent_command(backend, "fix it")
+    assert cmd[: len(expected_start)] == expected_start
+
+
+def test_agent_command_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        _agent_command("gpt-pilot", "fix it")
+
+
+def test_agent_command_stub_quotes_task():
+    cmd = _agent_command("stub", "task with 'quotes'")
+    # sh -c arg must safely contain the task
+    assert "task with" in cmd[-1]
+
+
+# ------------------------------------------------------------------ env vars
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_spec_env_passed_as_modal_secret(mock_create):
+    sb = MagicMock()
+    mock_create.return_value = sb
+    sb.exec.return_value = _make_proc()
+
+    with patch("sandbox.sandbox.modal.Secret.from_dict") as mock_secret:
+        mock_secret.return_value = MagicMock()
+        ModalSandbox(_config()).run(_spec(env={"FOO": "bar"}))
+
+    mock_secret.assert_called_once_with({"FOO": "bar"})
+
+
+@patch("sandbox.sandbox.modal.Sandbox.create")
+def test_empty_env_passes_no_secrets(mock_create):
+    sb = MagicMock()
+    mock_create.return_value = sb
+    sb.exec.return_value = _make_proc()
+
+    ModalSandbox(_config()).run(_spec(env={}))
+
+    _, kwargs = mock_create.call_args
+    assert kwargs["secrets"] == []


### PR DESCRIPTION
## What

Implements `ModalSandbox` — the core sandbox layer backed by `modal.Sandbox`. Replaces the previous devcontainer CLI approach.

## Changes

- **`sandbox/sandbox.py`**: `ModalSandbox` class — full lifecycle: create sandbox → clone repo → exec agent → collect diff → terminate (always, even on error)
- **`sandbox/config.py`**: drop Docker fields; `validate_connection()` now checks `modal --version` and `modal token current`
- **`sandbox/__init__.py`**: export `ModalSandbox`
- **`tests/unit/test_sandbox.py`**: 16 unit tests, Modal SDK fully mocked — no Modal account needed to run
- **`tests/unit/test_config.py`**: updated for new Modal-auth config shape

## Notes

- Local `modal/` package was removed — naming conflicts with the `modal` pip package. `ModalSandbox` lives in `sandbox/sandbox.py`
- `_agent_command` dispatches: `opencode` / `claude` / `gemini` / `stub`
- `terminate()` is always called (best-effort, errors swallowed) — no dangling sandboxes

Closes #29, closes #31