### PR TITLE
feat(tests): bug-fix integration test against fixture repo

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,10 @@
 name: E2E tests
 
 on:
-  # Manual trigger only — no nightly schedule until secrets + Daytona are configured.
-  # Once DAYTONA_API_KEY and ANTHROPIC_API_KEY are set as repo secrets,
-  # uncomment the schedule block below to enable nightly runs.
+  # Nightly run against the real model endpoint.
+  schedule:
+    - cron: "0 2 * * *"   # 02:00 UTC daily (~$0.05–0.10 per run)
+
   workflow_dispatch:
     inputs:
       backend:
@@ -13,17 +14,14 @@ on:
         type: choice
         options: [opencode, claude, gemini]
       model:
-        description: Model override (blank = default)
+        description: Model override (blank = qwen3-coder from OPENCODE_MODEL)
         required: false
         default: ""
 
-  # schedule:
-  #   - cron: "0 2 * * *"   # uncomment when ready for nightly runs (~$0.05/night)
-
 # E2E tests use a real LLM against the fixture repo.
-# Requires: DAYTONA_API_KEY, ANTHROPIC_API_KEY (or OPENAI_BASE_URL for self-hosted),
-#           GITHUB_TOKEN (auto-provided).
-# Cost: ~$0.05–0.10 per run using claude-haiku-4-5.
+# Requires repo secrets: MODAL_TOKEN_ID, MODAL_TOKEN_SECRET,
+#   OPENAI_BASE_URL (Modal serve endpoint), OPENAI_API_KEY (= "modal"),
+#   OPENCODE_MODEL (= "qwen3-coder"), GITHUB_TOKEN (auto-provided).
 
 jobs:
   check-secrets:
@@ -34,14 +32,14 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ -n "${{ secrets.DAYTONA_API_KEY }}" && \
-                ( -n "${{ secrets.ANTHROPIC_API_KEY }}" || \
-                  -n "${{ secrets.OPENAI_BASE_URL }}" ) ]]; then
+          if [[ -n "${{ secrets.MODAL_TOKEN_ID }}" && \
+                -n "${{ secrets.MODAL_TOKEN_SECRET }}" && \
+                -n "${{ secrets.OPENAI_BASE_URL }}" ]]; then
             echo "has-secrets=true" >> $GITHUB_OUTPUT
             echo "Required secrets present — proceeding with E2E tests"
           else
             echo "has-secrets=false" >> $GITHUB_OUTPUT
-            echo "::warning::E2E skipped — set DAYTONA_API_KEY and ANTHROPIC_API_KEY (or OPENAI_BASE_URL) as repo secrets"
+            echo "::warning::E2E skipped — set MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, OPENAI_BASE_URL as repo secrets"
           fi
 
   e2e:
@@ -52,13 +50,12 @@ jobs:
     timeout-minutes: 30
 
     env:
-      DAYTONA_SERVER_URL: ${{ secrets.DAYTONA_SERVER_URL || 'http://localhost:3986' }}
-      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AGENT_BACKEND: ${{ github.event.inputs.backend || 'opencode' }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
-      OPENCODE_MODEL: ${{ github.event.inputs.model || 'claude-haiku-4-5-20251001' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'modal' }}
+      OPENCODE_MODEL: ${{ github.event.inputs.model || secrets.OPENCODE_MODEL || 'qwen3-coder' }}
       FIXTURE_REPO: https://github.com/dvdthecoder/agent-container-fixture
 
     steps:
@@ -72,13 +69,8 @@ jobs:
       - name: Install dev dependencies
         run: pip install -e ".[dev]"
 
-      - name: Verify Daytona is reachable
-        run: |
-          curl -sf --max-time 10 "$DAYTONA_SERVER_URL/health" || \
-          (echo "::error::Daytona not reachable at $DAYTONA_SERVER_URL" && exit 1)
-
       - name: Run E2E tests
-        run: pytest tests/e2e/ -v --tb=short --junitxml=junit-e2e.xml -k "fixture"
+        run: pytest tests/integration/ tests/e2e/ -v --tb=short -m e2e --junitxml=junit-e2e.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
@@ -87,18 +79,3 @@ jobs:
           name: junit-e2e
           path: junit-e2e.xml
           retention-days: 30
-
-      - name: Verify no dangling workspaces
-        if: always()
-        run: |
-          python -c "
-          import subprocess, json, sys
-          result = subprocess.run(['daytona', 'list', '--json'], capture_output=True, text=True)
-          workspaces = json.loads(result.stdout or '[]')
-          leaked = [w for w in workspaces if w.get('name','').startswith('agent-')]
-          if leaked:
-              print(f'ERROR: {len(leaked)} workspace(s) not torn down:')
-              for w in leaked: print(f'  - {w[\"name\"]}')
-              sys.exit(1)
-          print('OK: no dangling workspaces')
-          "

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Integration tests use a stub agent — no LLM calls, no external API cost.
-# They require Daytona to be running and DAYTONA_API_KEY to be set as a repo secret.
-# If the secret is absent the job skips cleanly — nothing breaks.
+# Integration tests use the stub backend — no LLM calls, no external API cost.
+# They require a Modal token (MODAL_TOKEN_ID + MODAL_TOKEN_SECRET) set as repo secrets.
+# If the secrets are absent the job skips cleanly — nothing breaks.
 
 concurrency:
   group: integration-${{ github.ref }}
@@ -20,12 +20,10 @@ jobs:
     timeout-minutes: 15
 
     env:
-      DAYTONA_SERVER_URL: ${{ secrets.DAYTONA_SERVER_URL || 'http://localhost:3986' }}
-      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AGENT_BACKEND: stub
-      OPENAI_API_KEY: local
-      OPENAI_BASE_URL: http://localhost:30000/v1
+      FIXTURE_REPO: https://github.com/dvdthecoder/agent-container-fixture
 
     steps:
       - uses: actions/checkout@v6
@@ -38,47 +36,28 @@ jobs:
       - name: Install dev dependencies
         run: pip install -e ".[dev]"
 
-      - name: Check Daytona reachability
-        id: daytona-check
+      - name: Check Modal token
+        id: modal-check
         run: |
-          # Check secret at runtime rather than job-level if (secrets unreliable in job conditions)
-          if [ -z "$DAYTONA_API_KEY" ]; then
+          if [ -z "$MODAL_TOKEN_ID" ] || [ -z "$MODAL_TOKEN_SECRET" ]; then
             echo "reachable=false" >> $GITHUB_OUTPUT
-            echo "::warning::DAYTONA_API_KEY not set — integration tests skipped"
-          elif curl -sf --max-time 5 "$DAYTONA_SERVER_URL/health"; then
-            echo "reachable=true" >> $GITHUB_OUTPUT
+            echo "::warning::MODAL_TOKEN_ID / MODAL_TOKEN_SECRET not set — integration tests skipped"
           else
-            echo "reachable=false" >> $GITHUB_OUTPUT
-            echo "::warning::Daytona not reachable at $DAYTONA_SERVER_URL — integration tests skipped"
+            echo "reachable=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run integration tests
-        if: steps.daytona-check.outputs.reachable == 'true'
-        run: pytest tests/integration/ -v --tb=short --junitxml=junit-integration.xml
+      - name: Run integration tests (stub backend)
+        if: steps.modal-check.outputs.reachable == 'true'
+        run: pytest tests/integration/ -v --tb=short -m integration --junitxml=junit-integration.xml
 
       - name: Skip notice
-        if: steps.daytona-check.outputs.reachable == 'false'
-        run: echo "Integration tests skipped — set DAYTONA_SERVER_URL secret to a reachable instance"
+        if: steps.modal-check.outputs.reachable == 'false'
+        run: echo "Integration tests skipped — add MODAL_TOKEN_ID and MODAL_TOKEN_SECRET as repo secrets"
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
-        if: always() && steps.daytona-check.outputs.reachable == 'true'
+        if: always() && steps.modal-check.outputs.reachable == 'true'
         with:
           name: junit-integration
           path: junit-integration.xml
           retention-days: 14
-
-      - name: Verify no dangling workspaces
-        if: always() && steps.daytona-check.outputs.reachable == 'true'
-        run: |
-          python -c "
-          import subprocess, json, sys
-          result = subprocess.run(['daytona', 'list', '--json'], capture_output=True, text=True)
-          workspaces = json.loads(result.stdout or '[]')
-          leaked = [w for w in workspaces if w.get('name','').startswith('agent-')]
-          if leaked:
-              print(f'ERROR: {len(leaked)} workspace(s) not torn down:')
-              for w in leaked: print(f'  - {w[\"name\"]}')
-              sys.exit(1)
-          print('OK: no dangling workspaces')
-          "

--- a/tests/integration/test_fix_bug.py
+++ b/tests/integration/test_fix_bug.py
@@ -1,0 +1,101 @@
+"""Integration tests: agent fixes deliberate off-by-one bug in fixture repo.
+
+Fixture repo: https://github.com/dvdthecoder/agent-container-fixture
+Bug: sum_to_n() uses range(1, n) instead of range(1, n + 1)
+
+Test modes
+----------
+stub  (marker: integration) — runs on every PR via integration.yml
+    Uses backend="stub".  The stub agent only echoes the task — it does NOT
+    actually fix the code, so we assert the sandbox lifecycle works end-to-end
+    (sandbox created, cloned, agent ran, diff collected, sandbox torn down)
+    without making any LLM calls or spending money.
+
+real  (marker: e2e) — runs nightly via e2e.yml
+    Uses backend="opencode" against the Modal model endpoint.
+    Asserts the agent produced a diff that includes `range(1, n + 1)`.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox
+from sandbox.spec import AgentTaskSpec
+
+FIXTURE_REPO = os.getenv(
+    "FIXTURE_REPO",
+    "https://github.com/dvdthecoder/agent-container-fixture",
+)
+
+FIX_TASK = (
+    "The function sum_to_n() in mathlib.py has an off-by-one bug: "
+    "it uses range(1, n) but should use range(1, n + 1). "
+    "Fix the bug so that all tests in test_mathlib.py pass."
+)
+
+
+# ──────────────────────────────────────────────────────────── stub (integration)
+
+
+@pytest.mark.integration
+def test_stub_agent_runs_without_error():
+    """Sandbox lifecycle works end-to-end with the stub backend.
+
+    The stub agent echoes the task text — it does not modify any code — so
+    result.success reflects the agent's exit code (0), not whether the bug
+    was fixed.  The important thing is that Modal created the sandbox, cloned
+    the fixture repo, ran the agent, collected the diff, and tore down cleanly.
+    """
+    config = SandboxConfig.from_env()
+    spec = AgentTaskSpec(
+        repo=FIXTURE_REPO,
+        task=FIX_TASK,
+        backend="stub",
+        base_branch="main",
+        timeout_seconds=120,
+    )
+
+    result = ModalSandbox(config).run(spec)
+
+    assert result.success is True, f"Stub agent failed: {result.error}"
+    assert result.run_id != "unknown", "Sandbox did not get an object_id"
+    assert result.duration_seconds > 0
+    assert result.backend == "stub"
+    # Stub doesn't touch the code, so diff is empty
+    assert result.diff == ""
+
+
+# ──────────────────────────────────────────────────────────── real (e2e / nightly)
+
+
+@pytest.mark.e2e
+def test_opencode_agent_fixes_off_by_one():
+    """Real opencode agent fixes the bug and produces the correct diff.
+
+    Requires:
+    - MODAL_TOKEN_ID / MODAL_TOKEN_SECRET in environment
+    - OPENAI_BASE_URL pointing to the Modal model endpoint
+    - OPENAI_API_KEY set to "modal"
+    - OPENCODE_MODEL set to "qwen3-coder"
+    """
+    config = SandboxConfig.from_env()
+    spec = AgentTaskSpec(
+        repo=FIXTURE_REPO,
+        task=FIX_TASK,
+        backend="opencode",
+        base_branch="main",
+        timeout_seconds=300,
+    )
+
+    result = ModalSandbox(config).run(spec)
+
+    assert result.success is True, f"Agent failed:\n{result.error}"
+    assert result.diff, "Agent produced no diff — bug was not fixed"
+    assert "n + 1" in result.diff or "n+1" in result.diff, (
+        f"Expected fix (range(1, n + 1)) not found in diff:\n{result.diff}"
+    )
+    assert result.diff_stat, "diff --stat is empty"


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_fix_bug.py` with two test modes:
  - **stub** (`@pytest.mark.integration`) — runs on every PR via `integration.yml`. Exercises the full Modal sandbox lifecycle (create → clone → exec → diff → terminate) without making any LLM calls.
  - **real** (`@pytest.mark.e2e`) — runs nightly via `e2e.yml`. Dispatches opencode against the fixture repo and asserts the diff contains the correct fix (`range(1, n + 1)`).

- Updates `integration.yml`: replaces Daytona with Modal token check (`MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET`), runs `pytest -m integration`.

- Updates `e2e.yml`: replaces Daytona/Anthropic secrets with Modal secrets, enables nightly cron schedule (02:00 UTC), runs `pytest -m e2e`.

Fixture repo created: https://github.com/dvdthecoder/agent-container-fixture  
Bug: `sum_to_n()` uses `range(1, n)` instead of `range(1, n + 1)`

Closes #36

## Test plan

- [ ] CI unit tests pass
- [ ] Integration job skips cleanly when `MODAL_TOKEN_ID` secret is absent
- [ ] After adding Modal secrets: integration job runs and stub test passes
- [ ] Nightly e2e: real agent fixes the off-by-one and diff contains `n + 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)