### PR TITLE
fix(sandbox): unique Modal app per run to avoid collisions

### DIFF
--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import shlex
 import time
+import uuid
 
 import modal
 from sandbox.config import ConfigError, SandboxConfig
 from sandbox.result import AgentTaskResult
 from sandbox.spec import AgentTaskSpec
+
 
 # Base image — git + Node (for opencode) + Python pre-installed.
 # Built once by Modal and cached; subsequent runs reuse the cached layer.
@@ -42,8 +44,10 @@ class ModalSandbox:
     def run(self, spec: AgentTaskSpec) -> AgentTaskResult:
         start = time.monotonic()
         sb: modal.Sandbox | None = None
+        # Unique app per run — avoids collisions when multiple runs execute in parallel.
+        app = modal.App.lookup(f"agent-container-{uuid.uuid4().hex[:8]}", create_if_missing=True)
         try:
-            sb = self._create(spec)
+            sb = self._create(spec, app)
             self._clone(sb, spec)
             agent_output, exit_code = self._exec_agent(sb, spec)
             diff, diff_stat = self._collect_diff(sb)
@@ -73,7 +77,7 @@ class ModalSandbox:
 
     # ----------------------------------------------------------------- private
 
-    def _create(self, spec: AgentTaskSpec) -> modal.Sandbox:
+    def _create(self, spec: AgentTaskSpec, app: modal.App) -> modal.Sandbox:
         image = _BASE_IMAGE
         if spec.image:
             image = modal.Image.from_registry(spec.image)
@@ -84,6 +88,7 @@ class ModalSandbox:
             image=image,
             timeout=spec.timeout_seconds,
             secrets=[modal.Secret.from_dict(env)] if env else [],
+            app=app,
         )
 
     def _clone(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> None:

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -18,6 +18,13 @@ def _config() -> SandboxConfig:
     return SandboxConfig()
 
 
+@pytest.fixture(autouse=True)
+def mock_app_lookup():
+    """Prevent modal.App.lookup from hitting the Modal API in unit tests."""
+    with patch("sandbox.sandbox.modal.App.lookup", return_value=MagicMock()):
+        yield
+
+
 def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
     proc = MagicMock()
     proc.stdout.read.return_value = stdout


### PR DESCRIPTION
## Summary

- `modal.Sandbox.create` requires an app context when called outside a Modal container
- Each `ModalSandbox.run()` now creates a unique app (`agent-container-<8-char-uuid>`) via `modal.App.lookup(create_if_missing=True)` — parallel runs cannot collide
- Added `autouse` fixture in `test_sandbox.py` to mock `modal.App.lookup`, keeping all 66 unit tests fully offline

## Test plan

- [x] 66 unit tests pass (no Modal auth needed)
- [x] Stub integration test passes against real Modal sandbox (~69s end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)