### PR TITLE
fix(docs): enable GitHub Pages + bump actions to v6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,11 @@ jobs:
     name: Build and deploy MkDocs site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history for git-revision-date plugin
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip


### PR DESCRIPTION
## Summary

- GitHub Pages was not enabled on the repo — `mkdocs gh-deploy` was pushing to the `gh-pages` branch successfully but nothing was serving it. Enabled via API (`source: gh-pages /`).
- Bump `actions/checkout` and `actions/setup-python` from v4/v5 → v6 to clear Node.js 20 deprecation warnings.

Site is now live at https://dvdthecoder.github.io/agent-container/

🤖 Generated with [Claude Code](https://claude.com/claude-code)