### PR TITLE
feat(agent): iteration 1 — backends, runner, tester, git_ops

### DIFF
--- a/agent/backends/__init__.py
+++ b/agent/backends/__init__.py
@@ -1,11 +1,44 @@
+"""AgentBackend protocol and backend registry.
+
+A backend knows only *what command to run* inside the sandbox container.
+Execution (sb.exec) is handled by agent.runner — keeping backends fully
+decoupled from the Modal SDK and independently testable.
+"""
+
+from __future__ import annotations
+
 from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
 class AgentBackend(Protocol):
-    name: str
-    display_name: str
+    """Structural interface for a coding agent backend."""
 
-    def install(self, workspace: object) -> None: ...
+    name: str          # "opencode" | "claude" | "gemini" | "stub"
+    display_name: str  # human-readable name for UI / logging
 
-    def run(self, workspace: object, task: str, timeout: int) -> object: ...
+    def command(self, task: str) -> list[str]:
+        """Return the argv to invoke this agent non-interactively with *task*."""
+        ...
+
+
+def get_backend(name: str) -> AgentBackend:
+    """Return the backend for *name*, raising ``ValueError`` if unknown."""
+    # Deferred imports keep the individual backend modules independent.
+    from agent.backends.claude_code import ClaudeCodeBackend
+    from agent.backends.gemini import GeminiBackend
+    from agent.backends.opencode import OpenCodeBackend
+    from agent.backends.stub import StubBackend
+
+    registry: dict[str, AgentBackend] = {
+        "opencode": OpenCodeBackend(),
+        "claude": ClaudeCodeBackend(),
+        "gemini": GeminiBackend(),
+        "stub": StubBackend(),
+    }
+
+    if name not in registry:
+        raise ValueError(
+            f"Unknown backend: {name!r}. Available: {', '.join(registry)}"
+        )
+    return registry[name]

--- a/agent/backends/claude_code.py
+++ b/agent/backends/claude_code.py
@@ -1,0 +1,16 @@
+"""Claude Code CLI backend."""
+
+from __future__ import annotations
+
+
+class ClaudeCodeBackend:
+    """Run Claude Code CLI non-interactively with a task prompt.
+
+    Reads ``ANTHROPIC_API_KEY`` from the environment.
+    """
+
+    name = "claude"
+    display_name = "Claude Code"
+
+    def command(self, task: str) -> list[str]:
+        return ["claude", "--print", task]

--- a/agent/backends/gemini.py
+++ b/agent/backends/gemini.py
@@ -1,0 +1,17 @@
+"""Gemini CLI backend."""
+
+from __future__ import annotations
+
+
+class GeminiBackend:
+    """Run Gemini CLI non-interactively with a task prompt.
+
+    Reads ``GEMINI_API_KEY`` from the environment.
+    ``--yolo`` suppresses interactive confirmations.
+    """
+
+    name = "gemini"
+    display_name = "Gemini CLI"
+
+    def command(self, task: str) -> list[str]:
+        return ["gemini", "--yolo", "-p", task]

--- a/agent/backends/opencode.py
+++ b/agent/backends/opencode.py
@@ -1,0 +1,17 @@
+"""OpenCode backend — default agent for agent-container."""
+
+from __future__ import annotations
+
+
+class OpenCodeBackend:
+    """Run OpenCode non-interactively with a task prompt.
+
+    OpenCode reads ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` / ``OPENCODE_MODEL``
+    from the environment — these are injected via Modal secrets.
+    """
+
+    name = "opencode"
+    display_name = "OpenCode"
+
+    def command(self, task: str) -> list[str]:
+        return ["opencode", "--print", "-m", task]

--- a/agent/backends/stub.py
+++ b/agent/backends/stub.py
@@ -1,0 +1,19 @@
+"""Stub backend — echoes the task, makes no code changes.
+
+Used in integration tests to validate the full sandbox lifecycle
+(create → clone → run → diff → PR → destroy) without spending money on a
+real model call.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+
+class StubBackend:
+    name = "stub"
+    display_name = "Stub (testing only)"
+
+    def command(self, task: str) -> list[str]:
+        # Echo the task to stdout so callers can verify the agent ran.
+        return ["sh", "-c", f"echo {shlex.quote(task)}"]

--- a/agent/git_ops.py
+++ b/agent/git_ops.py
@@ -1,0 +1,155 @@
+"""Git operations that run inside a Modal sandbox workspace.
+
+All functions receive a ``modal.Sandbox`` instance and execute git commands
+inside it via ``sb.exec``.  Nothing here touches the local filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from datetime import datetime, timezone
+
+import modal
+
+from sandbox.config import ConfigError, SandboxConfig
+from sandbox.providers import RepoProvider, detect_provider
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def branch_name(backend: str) -> str:
+    """Return a time-stamped branch name for an agent run.
+
+    Format: ``agent/<backend>-YYYYMMDD-HHMMSS``
+    """
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"agent/{backend}-{ts}"
+
+
+def clone(sb: modal.Sandbox, repo: str, base_branch: str) -> None:
+    """Clone *repo* at *base_branch* into ``/workspace`` inside the sandbox."""
+    proc = sb.exec(
+        "git", "clone",
+        "--branch", base_branch,
+        "--depth", "1",
+        repo,
+        "/workspace",
+    )
+    proc.wait()
+    if proc.returncode != 0:
+        raise ConfigError(f"git clone failed:\n{proc.stderr.read()}")
+
+
+def collect_diff(sb: modal.Sandbox, workdir: str = "/workspace") -> tuple[str, str]:
+    """Return ``(full_diff, diff_stat)`` for uncommitted changes in *workdir*."""
+    diff_proc = sb.exec("git", "diff", "HEAD", workdir=workdir)
+    diff = diff_proc.stdout.read()
+    diff_proc.wait()
+
+    stat_proc = sb.exec("git", "diff", "--stat", "HEAD", workdir=workdir)
+    stat = stat_proc.stdout.read()
+    stat_proc.wait()
+
+    return diff, stat.strip()
+
+
+def push_and_pr(
+    sb: modal.Sandbox,
+    repo: str,
+    base_branch: str,
+    backend: str,
+    task: str,
+    config: SandboxConfig,
+    workdir: str = "/workspace",
+) -> tuple[str, str | None]:
+    """Stage, commit, push on a new branch, and open a PR / MR.
+
+    Returns ``(branch_name, pr_url)``.  ``pr_url`` is ``None`` when the host
+    is unsupported or the access token is not configured.
+    """
+    br = branch_name(backend)
+
+    try:
+        provider = detect_provider(repo)
+    except ValueError:
+        return br, None  # unsupported host — skip push and PR
+
+    token = config.token_for(provider.name)
+    if not token:
+        return br, None  # no token — skip push and PR
+
+    # git identity is required to create a commit inside the container.
+    _git(sb, ["config", "user.email", "agent@agent-container"], workdir)
+    _git(sb, ["config", "user.name", "Agent Container"], workdir)
+    _git(sb, ["checkout", "-b", br], workdir)
+    _git(sb, ["add", "-A"], workdir)
+    _git(sb, ["commit", "-m", f"agent: {task[:72]}"], workdir)
+
+    # Rewrite the remote URL to embed the token so `git push` can authenticate.
+    authed_url = provider.authed_remote(repo, token)
+    _git(sb, ["remote", "set-url", "origin", authed_url], workdir)
+
+    push_proc = sb.exec("git", "push", "origin", br, workdir=workdir)
+    push_proc.wait()
+    if push_proc.returncode != 0:
+        raise ConfigError(f"git push failed:\n{push_proc.stderr.read()}")
+
+    owner, repo_name = provider.parse_repo(repo)
+    pr_url = _open_pr(sb, provider, owner, repo_name, br, base_branch, backend, task, workdir)
+    return br, pr_url
+
+
+# ── Private helpers ───────────────────────────────────────────────────────────
+
+
+def _git(sb: modal.Sandbox, args: list[str], workdir: str) -> None:
+    """Run a git sub-command in *workdir*, raising ``ConfigError`` on failure."""
+    proc = sb.exec("git", *args, workdir=workdir)
+    proc.wait()
+    if proc.returncode != 0:
+        raise ConfigError(f"git {args[0]} failed:\n{proc.stderr.read()}")
+
+
+def _open_pr(
+    sb: modal.Sandbox,
+    provider: RepoProvider,
+    owner: str,
+    repo_name: str,
+    br: str,
+    base_branch: str,
+    backend: str,
+    task: str,
+    workdir: str,
+) -> str | None:
+    """Open a PR / MR via the provider REST API. Returns the PR / MR URL."""
+    payload = json.dumps(provider.pr_payload(
+        title=task[:72],
+        head_branch=br,
+        base_branch=base_branch,
+        body=f"Automated change by agent-container (`{backend}`).\n\n**Task:**\n{task}",
+    ))
+
+    # Write payload to a temp file so we don't need to quote JSON in a shell string.
+    write_proc = sb.exec(
+        "sh", "-c",
+        f"printf '%s' {shlex.quote(payload)} > /tmp/pr_payload.json",
+    )
+    write_proc.wait()
+
+    # Build the curl command with provider-specific headers.
+    # Headers may reference container env vars (e.g. $GITHUB_TOKEN) which the
+    # shell expands because the whole command runs under `sh -c`.
+    header_flags = " ".join(f'-H "{h}"' for h in provider.pr_headers())
+    api_url = provider.pr_api_url(owner, repo_name)
+    curl_proc = sb.exec(
+        "sh", "-c",
+        f"curl -sf -X POST {header_flags} {api_url} -d @/tmp/pr_payload.json",
+    )
+    response = curl_proc.stdout.read()
+    curl_proc.wait()
+    if curl_proc.returncode != 0:
+        raise ConfigError(f"PR creation failed:\n{curl_proc.stderr.read()}")
+
+    data = json.loads(response)
+    return data.get(provider.pr_url_field())

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -1,0 +1,26 @@
+"""Execute a coding agent backend inside a Modal sandbox workspace."""
+
+from __future__ import annotations
+
+import modal
+
+from agent.backends import AgentBackend
+
+
+def run_agent(
+    sb: modal.Sandbox,
+    backend: AgentBackend,
+    task: str,
+    workdir: str = "/workspace",
+) -> tuple[str, int]:
+    """Run *backend* with *task* inside *sb*. Returns ``(stdout, exit_code)``.
+
+    The caller is responsible for interpreting the exit code — a non-zero
+    value means the agent reported failure but does not necessarily mean no
+    useful output was produced.
+    """
+    cmd = backend.command(task)
+    proc = sb.exec(*cmd, workdir=workdir)
+    output = proc.stdout.read()
+    proc.wait()
+    return output, proc.returncode

--- a/agent/tester.py
+++ b/agent/tester.py
@@ -1,0 +1,115 @@
+"""Auto-detect and run the project test suite inside a Modal sandbox workspace.
+
+Detection order: pytest → npm → cargo → go.  The first matching runner wins.
+Returns ``None`` if no recognisable test configuration is found.
+"""
+
+from __future__ import annotations
+
+import re
+
+import modal
+
+from sandbox.result import SuiteResult
+
+# ── Detection ────────────────────────────────────────────────────────────────
+
+# Shell fragment that evaluates to true when the runner's marker file exists.
+_DETECT_CONDITIONS: list[tuple[str, str]] = [
+    (
+        "pytest",
+        "[ -f pytest.ini ] || [ -f setup.cfg ]"
+        " || ([ -f pyproject.toml ] && grep -q 'tool.pytest' pyproject.toml 2>/dev/null)"
+        " || (find . -maxdepth 2 -name 'test_*.py' | grep -q . 2>/dev/null)",
+    ),
+    ("npm",   "[ -f package.json ]"),
+    ("cargo", "[ -f Cargo.toml ]"),
+    ("go",    "[ -f go.mod ]"),
+]
+
+# Command to run for each runner (executed in /workspace).
+_RUN_COMMANDS: dict[str, list[str]] = {
+    "pytest": ["python", "-m", "pytest", "--tb=short", "-q"],
+    "npm":    ["npm", "test", "--", "--no-coverage"],
+    "cargo":  ["cargo", "test"],
+    "go":     ["go", "test", "./..."],
+}
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def detect_and_run(
+    sb: modal.Sandbox,
+    workdir: str = "/workspace",
+) -> SuiteResult | None:
+    """Detect the test runner in *workdir* and run the suite.
+
+    Returns a :class:`~sandbox.result.SuiteResult` on success or failure, or
+    ``None`` if no test runner configuration was found.
+    """
+    runner_name = _detect_runner(sb, workdir)
+    if runner_name is None:
+        return None
+    return _run_tests(sb, runner_name, workdir)
+
+
+# ── Private helpers ───────────────────────────────────────────────────────────
+
+
+def _detect_runner(sb: modal.Sandbox, workdir: str) -> str | None:
+    """Return the name of the first matching test runner, or ``None``."""
+    # Build a single sh -c command that echoes the runner name or "none".
+    branches = " ".join(
+        f"if {cond}; then echo {name}; el"
+        for name, cond in _DETECT_CONDITIONS
+    )
+    # Close the if-elif chain.
+    script = branches + "se echo none; fi"
+
+    proc = sb.exec("sh", "-c", script, workdir=workdir)
+    output = proc.stdout.read().strip()
+    proc.wait()
+
+    return None if output == "none" else output
+
+
+def _run_tests(
+    sb: modal.Sandbox,
+    runner_name: str,
+    workdir: str,
+) -> SuiteResult:
+    """Run the test suite and return a structured result."""
+    cmd = _RUN_COMMANDS[runner_name]
+    proc = sb.exec(*cmd, workdir=workdir)
+    output = proc.stdout.read()
+    proc.wait()
+    exit_code = proc.returncode
+
+    passed, failed = _parse_counts(runner_name, output, exit_code)
+    return SuiteResult(
+        passed=passed,
+        failed=failed,
+        output=output,
+        runner_name=runner_name,
+    )
+
+
+def _parse_counts(runner_name: str, output: str, exit_code: int) -> tuple[int, int]:
+    """Extract (passed, failed) counts from test output, falling back to exit code."""
+    if runner_name in ("pytest", "npm"):
+        passed = int(m.group(1)) if (m := re.search(r"(\d+) passed", output)) else 0
+        failed = int(m.group(1)) if (m := re.search(r"(\d+) failed", output)) else 0
+        # If we couldn't parse counts, infer from exit code.
+        if passed == 0 and failed == 0:
+            return (1, 0) if exit_code == 0 else (0, 1)
+        return passed, failed
+
+    if runner_name == "cargo":
+        # "test result: ok. 5 passed; 0 failed"
+        m = re.search(r"(\d+) passed; (\d+) failed", output)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+        return (1, 0) if exit_code == 0 else (0, 1)
+
+    # go — "ok  github.com/..." or "FAIL\t..." — use exit code only.
+    return (1, 0) if exit_code == 0 else (0, 1)

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -1,17 +1,22 @@
-"""Modal-based agent sandbox: boot → exec → teardown."""
+"""Modal-based agent sandbox: boot → exec → teardown.
+
+ModalSandbox is the orchestrator.  Domain logic lives in dedicated modules:
+  agent.git_ops  — clone, diff, push, PR
+  agent.runner   — invoke the coding agent backend
+  agent.tester   — detect and run the project test suite
+  agent.backends — per-backend command construction
+"""
 
 from __future__ import annotations
 
-import json
-import shlex
 import time
 import uuid
-from datetime import datetime, timezone
 
 import modal
-from sandbox.config import ConfigError, SandboxConfig
-from sandbox.providers import RepoProvider, detect_provider
-from sandbox.result import AgentTaskResult
+from agent import git_ops, runner, tester
+from agent.backends import get_backend
+from sandbox.config import SandboxConfig
+from sandbox.result import AgentTaskResult, SuiteResult
 from sandbox.spec import AgentTaskSpec
 
 # Base image — git + Node (for opencode) + Python pre-installed.
@@ -32,10 +37,12 @@ class ModalSandbox:
 
     Lifecycle per call to :meth:`run`:
       1. Create a Modal sandbox with the configured image
-      2. Clone the target repo inside the sandbox
-      3. Run the coding agent (opencode / claude / gemini / stub)
-      4. Collect ``git diff`` output
-      5. Terminate the sandbox (always, even on failure)
+      2. Clone the target repo
+      3. Run the coding agent backend
+      4. Run the project test suite (if ``spec.run_tests`` is True)
+      5. Collect ``git diff`` output
+      6. Push branch and open PR (if ``spec.create_pr`` is True and diff is non-empty)
+      7. Terminate the sandbox (always, even on failure)
     """
 
     def __init__(self, config: SandboxConfig) -> None:
@@ -51,14 +58,28 @@ class ModalSandbox:
         try:
             try:
                 sb = self._create(spec, app)
-                self._clone(sb, spec)
-                agent_output, exit_code = self._exec_agent(sb, spec)
-                diff, diff_stat = self._collect_diff(sb)
+                git_ops.clone(sb, spec.repo, spec.base_branch)
+
+                backend = get_backend(spec.backend)
+                agent_output, exit_code = runner.run_agent(sb, backend, spec.resolved_task())
+
+                suite: SuiteResult | None = None
+                if exit_code == 0 and spec.run_tests:
+                    suite = tester.detect_and_run(sb)
+
+                diff, diff_stat = git_ops.collect_diff(sb)
 
                 branch: str | None = None
                 pr_url: str | None = None
                 if exit_code == 0 and diff and spec.create_pr:
-                    branch, pr_url = self._push_and_pr(sb, spec)
+                    branch, pr_url = git_ops.push_and_pr(
+                        sb,
+                        repo=spec.repo,
+                        base_branch=spec.base_branch,
+                        backend=spec.backend,
+                        task=spec.resolved_task(),
+                        config=self.config,
+                    )
 
             except Exception as exc:
                 return AgentTaskResult(
@@ -76,6 +97,7 @@ class ModalSandbox:
                 pr_url=pr_url,
                 diff=diff,
                 diff_stat=diff_stat,
+                tests=suite,
                 duration_seconds=time.monotonic() - start,
                 error=None if exit_code == 0 else agent_output,
                 backend=spec.backend,
@@ -100,148 +122,8 @@ class ModalSandbox:
             app=app,
         )
 
-    def _clone(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> None:
-        proc = sb.exec(
-            "git",
-            "clone",
-            "--branch",
-            spec.base_branch,
-            "--depth",
-            "1",
-            spec.repo,
-            "/workspace",
-        )
-        proc.wait()
-        if proc.returncode != 0:
-            raise ConfigError(f"git clone failed:\n{proc.stderr.read()}")
-
-    def _exec_agent(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> tuple[str, int]:
-        cmd = _agent_command(spec.backend, spec.resolved_task())
-        proc = sb.exec(*cmd, workdir="/workspace")
-        output = proc.stdout.read()
-        proc.wait()
-        return output, proc.returncode
-
-    def _collect_diff(self, sb: modal.Sandbox) -> tuple[str, str]:
-        diff_proc = sb.exec("git", "diff", "HEAD", workdir="/workspace")
-        diff = diff_proc.stdout.read()
-        diff_proc.wait()
-
-        stat_proc = sb.exec("git", "diff", "--stat", "HEAD", workdir="/workspace")
-        stat = stat_proc.stdout.read()
-        stat_proc.wait()
-
-        return diff, stat.strip()
-
-    def _push_and_pr(self, sb: modal.Sandbox, spec: AgentTaskSpec) -> tuple[str, str | None]:
-        """Stage, commit, push on a new branch, and open a PR / MR via the provider API.
-
-        Returns ``(branch_name, pr_url)``.  ``pr_url`` is ``None`` when the host is
-        unsupported or the access token is not configured.
-        """
-        branch = _branch_name(spec.backend)
-
-        try:
-            provider = detect_provider(spec.repo)
-        except ValueError:
-            return branch, None  # unsupported host — skip push and PR
-
-        token = self.config.token_for(provider.name)
-        if not token:
-            return branch, None  # no token — skip push and PR
-
-        # git identity is required to create a commit inside the container.
-        self._git(sb, ["config", "user.email", "agent@agent-container"])
-        self._git(sb, ["config", "user.name", "Agent Container"])
-
-        self._git(sb, ["checkout", "-b", branch])
-        self._git(sb, ["add", "-A"])
-        self._git(sb, ["commit", "-m", f"agent: {spec.resolved_task()[:72]}"])
-
-        # Rewrite the remote URL to embed the token so `git push` can authenticate.
-        authed_url = provider.authed_remote(spec.repo, token)
-        self._git(sb, ["remote", "set-url", "origin", authed_url])
-
-        push_proc = sb.exec("git", "push", "origin", branch, workdir="/workspace")
-        push_proc.wait()
-        if push_proc.returncode != 0:
-            raise ConfigError(f"git push failed:\n{push_proc.stderr.read()}")
-
-        owner, repo_name = provider.parse_repo(spec.repo)
-        pr_url = self._open_pr(sb, provider, owner, repo_name, branch, spec)
-        return branch, pr_url
-
-    def _open_pr(
-        self,
-        sb: modal.Sandbox,
-        provider: RepoProvider,
-        owner: str,
-        repo_name: str,
-        branch: str,
-        spec: AgentTaskSpec,
-    ) -> str | None:
-        """Open a PR / MR via the provider REST API. Returns the PR / MR URL."""
-        task = spec.resolved_task()
-        payload = json.dumps(provider.pr_payload(
-            title=task[:72],
-            head_branch=branch,
-            base_branch=spec.base_branch,
-            body=f"Automated change by agent-container (`{spec.backend}`).\n\n**Task:**\n{task}",
-        ))
-
-        # Write the payload to a temp file so we don't need to quote JSON inside a
-        # shell command string — `printf '%s'` treats the argument verbatim.
-        write_proc = sb.exec(
-            "sh", "-c",
-            f"printf '%s' {shlex.quote(payload)} > /tmp/pr_payload.json",
-        )
-        write_proc.wait()
-
-        # Build the curl command with provider-specific headers.
-        # Headers may reference container env vars (e.g. $GITHUB_TOKEN) which the
-        # shell expands because the whole command runs under `sh -c`.
-        header_flags = " ".join(f'-H "{h}"' for h in provider.pr_headers())
-        api_url = provider.pr_api_url(owner, repo_name)
-        curl_proc = sb.exec(
-            "sh", "-c",
-            f"curl -sf -X POST {header_flags} {api_url} -d @/tmp/pr_payload.json",
-        )
-        response = curl_proc.stdout.read()
-        curl_proc.wait()
-        if curl_proc.returncode != 0:
-            raise ConfigError(f"PR creation failed:\n{curl_proc.stderr.read()}")
-
-        data = json.loads(response)
-        return data.get(provider.pr_url_field())
-
-    def _git(self, sb: modal.Sandbox, args: list[str]) -> None:
-        """Run a git sub-command in /workspace, raising ConfigError on non-zero exit."""
-        proc = sb.exec("git", *args, workdir="/workspace")
-        proc.wait()
-        if proc.returncode != 0:
-            raise ConfigError(f"git {args[0]} failed:\n{proc.stderr.read()}")
-
 
 # ------------------------------------------------------------------ helpers
-
-
-def _branch_name(backend: str) -> str:
-    """Return a deterministic, time-stamped branch name for an agent run."""
-    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
-    return f"agent/{backend}-{ts}"
-
-
-def _agent_command(backend: str, task: str) -> list[str]:
-    """Return the argv to run the coding agent inside the sandbox."""
-    if backend == "opencode":
-        return ["opencode", "--print", "-m", task]
-    if backend == "claude":
-        return ["claude", "--print", task]
-    if backend == "gemini":
-        return ["gemini", "--yolo", "-p", task]
-    if backend == "stub":
-        return ["sh", "-c", f"echo {shlex.quote(task)}"]
-    raise ValueError(f"Unknown backend: {backend!r}")
 
 
 def _terminate(sb: modal.Sandbox | None) -> None:

--- a/sandbox/spec.py
+++ b/sandbox/spec.py
@@ -16,6 +16,7 @@ class AgentTaskSpec:
     env: dict[str, str] = field(default_factory=dict)
     timeout_seconds: int = 300
     create_pr: bool = True
+    run_tests: bool = True      # auto-detect and run the project test suite
     backend: str = "opencode"  # opencode | claude | gemini
 
     def __post_init__(self) -> None:

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,0 +1,102 @@
+"""Unit tests for agent.backends — protocol conformance, commands, registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.backends import AgentBackend, get_backend
+from agent.backends.claude_code import ClaudeCodeBackend
+from agent.backends.gemini import GeminiBackend
+from agent.backends.opencode import OpenCodeBackend
+from agent.backends.stub import StubBackend
+
+# ------------------------------------------------------------------ Protocol
+
+
+@pytest.mark.parametrize("backend_cls", [
+    OpenCodeBackend, ClaudeCodeBackend, GeminiBackend, StubBackend,
+])
+def test_satisfies_protocol(backend_cls):
+    assert isinstance(backend_cls(), AgentBackend)
+
+
+# ------------------------------------------------------------------ commands
+
+
+def test_opencode_command():
+    cmd = OpenCodeBackend().command("fix the bug")
+    assert cmd == ["opencode", "--print", "-m", "fix the bug"]
+
+
+def test_claude_command():
+    cmd = ClaudeCodeBackend().command("fix the bug")
+    assert cmd == ["claude", "--print", "fix the bug"]
+
+
+def test_gemini_command():
+    cmd = GeminiBackend().command("fix the bug")
+    assert cmd == ["gemini", "--yolo", "-p", "fix the bug"]
+
+
+def test_stub_command_starts_with_sh():
+    cmd = StubBackend().command("fix the bug")
+    assert cmd[:2] == ["sh", "-c"]
+
+
+def test_stub_command_safely_quotes_task():
+    cmd = StubBackend().command("task with 'single quotes'")
+    # The shell fragment must contain the task text safely quoted.
+    assert "task with" in cmd[-1]
+
+
+@pytest.mark.parametrize("backend_name, expected_prefix", [
+    ("opencode", ["opencode", "--print", "-m"]),
+    ("claude",   ["claude", "--print"]),
+    ("gemini",   ["gemini", "--yolo", "-p"]),
+    ("stub",     ["sh", "-c"]),
+])
+def test_command_prefix(backend_name, expected_prefix):
+    backend = get_backend(backend_name)
+    cmd = backend.command("task")
+    assert cmd[: len(expected_prefix)] == expected_prefix
+
+
+# ------------------------------------------------------------------ names
+
+
+@pytest.mark.parametrize("backend_cls, expected_name", [
+    (OpenCodeBackend,  "opencode"),
+    (ClaudeCodeBackend, "claude"),
+    (GeminiBackend,    "gemini"),
+    (StubBackend,      "stub"),
+])
+def test_name_attribute(backend_cls, expected_name):
+    assert backend_cls().name == expected_name
+
+
+@pytest.mark.parametrize("backend_cls", [
+    OpenCodeBackend, ClaudeCodeBackend, GeminiBackend, StubBackend,
+])
+def test_display_name_is_non_empty_string(backend_cls):
+    assert isinstance(backend_cls().display_name, str)
+    assert backend_cls().display_name
+
+
+# ------------------------------------------------------------------ registry
+
+
+def test_get_backend_returns_correct_type():
+    assert isinstance(get_backend("opencode"), OpenCodeBackend)
+    assert isinstance(get_backend("claude"), ClaudeCodeBackend)
+    assert isinstance(get_backend("gemini"), GeminiBackend)
+    assert isinstance(get_backend("stub"), StubBackend)
+
+
+def test_get_backend_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        get_backend("gpt-pilot")
+
+
+def test_get_backend_error_lists_available():
+    with pytest.raises(ValueError, match="opencode"):
+        get_backend("unknown")

--- a/tests/unit/test_git_ops.py
+++ b/tests/unit/test_git_ops.py
@@ -1,0 +1,182 @@
+"""Unit tests for agent.git_ops — all git operations run inside a mocked sandbox."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.git_ops import branch_name, clone, collect_diff, push_and_pr
+from sandbox.config import ConfigError, SandboxConfig
+
+
+def _make_proc(stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout.read.return_value = stdout
+    proc.stderr.read.return_value = stderr
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ------------------------------------------------------------------ branch_name
+
+
+def test_branch_name_format():
+    br = branch_name("opencode")
+    assert br.startswith("agent/opencode-")
+    ts = br[len("agent/opencode-"):]
+    assert len(ts) == 15  # YYYYMMDD-HHMMSS
+    assert ts[8] == "-"
+
+
+def test_branch_name_uses_backend():
+    assert branch_name("claude").startswith("agent/claude-")
+    assert branch_name("gemini").startswith("agent/gemini-")
+
+
+# ------------------------------------------------------------------ clone
+
+
+def test_clone_success():
+    sb = MagicMock()
+    sb.exec.return_value = _make_proc(returncode=0)
+
+    clone(sb, "https://github.com/org/repo", "main")
+
+    sb.exec.assert_called_once_with(
+        "git", "clone", "--branch", "main", "--depth", "1",
+        "https://github.com/org/repo", "/workspace",
+    )
+
+
+def test_clone_failure_raises_config_error():
+    sb = MagicMock()
+    sb.exec.return_value = _make_proc(stderr="fatal: not found", returncode=1)
+
+    with pytest.raises(ConfigError, match="git clone failed"):
+        clone(sb, "https://github.com/org/repo", "main")
+
+
+# ------------------------------------------------------------------ collect_diff
+
+
+def test_collect_diff_returns_diff_and_stat():
+    sb = MagicMock()
+    diff_proc = _make_proc(stdout="diff --git a/f b/f\n+fix")
+    stat_proc = _make_proc(stdout=" 1 file changed, 1 insertion(+)\n")
+    sb.exec.side_effect = [diff_proc, stat_proc]
+
+    diff, stat = collect_diff(sb)
+
+    assert diff == "diff --git a/f b/f\n+fix"
+    assert stat == "1 file changed, 1 insertion(+)"  # stripped
+
+
+def test_collect_diff_empty_when_no_changes():
+    sb = MagicMock()
+    sb.exec.return_value = _make_proc(stdout="")
+
+    diff, stat = collect_diff(sb)
+
+    assert diff == ""
+    assert stat == ""
+
+
+# ------------------------------------------------------------------ push_and_pr
+
+
+def _pr_config(token: str = "ghp_test") -> SandboxConfig:
+    return SandboxConfig(github_token=token)
+
+
+def _pr_procs(pr_response: str = '{"html_url": "https://github.com/org/repo/pull/1"}'):
+    """Return the standard sequence of mock procs for a successful push_and_pr call."""
+    git_procs = [_make_proc() for _ in range(6)]  # config×2, checkout, add, commit, remote
+    push_proc = _make_proc(returncode=0)
+    write_proc = _make_proc()
+    curl_proc = _make_proc(stdout=pr_response)
+    return [*git_procs, push_proc, write_proc, curl_proc]
+
+
+def test_push_and_pr_returns_branch_and_pr_url():
+    sb = MagicMock()
+    sb.exec.side_effect = _pr_procs()
+
+    br, pr_url = push_and_pr(
+        sb,
+        repo="https://github.com/org/repo",
+        base_branch="main",
+        backend="opencode",
+        task="fix the bug",
+        config=_pr_config(),
+    )
+
+    assert br.startswith("agent/opencode-")
+    assert pr_url == "https://github.com/org/repo/pull/1"
+
+
+def test_push_and_pr_skips_when_no_token():
+    sb = MagicMock()
+
+    br, pr_url = push_and_pr(
+        sb,
+        repo="https://github.com/org/repo",
+        base_branch="main",
+        backend="opencode",
+        task="fix the bug",
+        config=SandboxConfig(),  # no github_token
+    )
+
+    assert br.startswith("agent/opencode-")
+    assert pr_url is None
+    sb.exec.assert_not_called()
+
+
+def test_push_and_pr_skips_for_unsupported_host():
+    sb = MagicMock()
+
+    br, pr_url = push_and_pr(
+        sb,
+        repo="https://bitbucket.org/org/repo",
+        base_branch="main",
+        backend="opencode",
+        task="fix the bug",
+        config=_pr_config(),
+    )
+
+    assert pr_url is None
+    sb.exec.assert_not_called()
+
+
+def test_push_failure_raises_config_error():
+    sb = MagicMock()
+    git_procs = [_make_proc() for _ in range(6)]
+    push_proc = _make_proc(stderr="remote: Permission denied", returncode=1)
+    sb.exec.side_effect = [*git_procs, push_proc]
+
+    with pytest.raises(ConfigError, match="git push failed"):
+        push_and_pr(
+            sb,
+            repo="https://github.com/org/repo",
+            base_branch="main",
+            backend="opencode",
+            task="fix the bug",
+            config=_pr_config(),
+        )
+
+
+def test_gitlab_push_and_pr():
+    sb = MagicMock()
+    sb.exec.side_effect = _pr_procs(pr_response='{"web_url": "https://gitlab.com/org/repo/-/merge_requests/5"}')
+
+    br, pr_url = push_and_pr(
+        sb,
+        repo="https://gitlab.com/org/repo",
+        base_branch="main",
+        backend="opencode",
+        task="fix the bug",
+        config=SandboxConfig(gitlab_token="glpat_test"),
+    )
+
+    assert pr_url == "https://gitlab.com/org/repo/-/merge_requests/5"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,86 @@
+"""Unit tests for agent.runner — Modal sandbox fully mocked."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.backends.claude_code import ClaudeCodeBackend
+from agent.backends.gemini import GeminiBackend
+from agent.backends.opencode import OpenCodeBackend
+from agent.backends.stub import StubBackend
+from agent.runner import run_agent
+
+
+def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout.read.return_value = stdout
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+def _make_sb(stdout: str = "", returncode: int = 0) -> MagicMock:
+    sb = MagicMock()
+    sb.exec.return_value = _make_proc(stdout=stdout, returncode=returncode)
+    return sb
+
+
+# ------------------------------------------------------------------ basic contract
+
+
+def test_returns_stdout_and_exit_code():
+    sb = _make_sb(stdout="agent output", returncode=0)
+    output, code = run_agent(sb, OpenCodeBackend(), "fix it")
+    assert output == "agent output"
+    assert code == 0
+
+
+def test_non_zero_exit_code_returned_as_is():
+    sb = _make_sb(stdout="error detail", returncode=1)
+    output, code = run_agent(sb, OpenCodeBackend(), "fix it")
+    assert code == 1
+    assert output == "error detail"
+
+
+# ------------------------------------------------------------------ command dispatch
+
+
+@pytest.mark.parametrize("backend, expected_argv_start", [
+    (OpenCodeBackend(),  ["opencode", "--print", "-m"]),
+    (ClaudeCodeBackend(), ["claude", "--print"]),
+    (GeminiBackend(),    ["gemini", "--yolo", "-p"]),
+    (StubBackend(),      ["sh", "-c"]),
+])
+def test_exec_called_with_backend_command(backend, expected_argv_start):
+    sb = _make_sb()
+    run_agent(sb, backend, "my task")
+
+    call_args = sb.exec.call_args
+    argv = list(call_args[0])
+    assert argv[: len(expected_argv_start)] == expected_argv_start
+
+
+def test_task_passed_to_command():
+    sb = _make_sb()
+    run_agent(sb, OpenCodeBackend(), "add rate limiting")
+    argv = list(sb.exec.call_args[0])
+    assert "add rate limiting" in argv
+
+
+# ------------------------------------------------------------------ workdir
+
+
+def test_default_workdir_is_workspace():
+    sb = _make_sb()
+    run_agent(sb, OpenCodeBackend(), "task")
+    _, kwargs = sb.exec.call_args
+    assert kwargs.get("workdir") == "/workspace"
+
+
+def test_custom_workdir_is_forwarded():
+    sb = _make_sb()
+    run_agent(sb, OpenCodeBackend(), "task", workdir="/custom")
+    _, kwargs = sb.exec.call_args
+    assert kwargs.get("workdir") == "/custom"

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -5,12 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sandbox.config import SandboxConfig
-from sandbox.sandbox import ModalSandbox, _agent_command, _branch_name
+from sandbox.sandbox import ModalSandbox
 from sandbox.spec import AgentTaskSpec
 
 
 def _spec(**kwargs) -> AgentTaskSpec:
-    defaults = dict(repo="https://github.com/org/repo", task="fix it")
+    # run_tests=False keeps side_effect lists predictable — tester tests are in test_tester.py
+    defaults = dict(repo="https://github.com/org/repo", task="fix it", run_tests=False)
     return AgentTaskSpec(**{**defaults, **kwargs})
 
 
@@ -275,34 +276,6 @@ def test_sandbox_create_failure_returns_failed_result(_mock_create):
     assert "Modal API error" in result.error
 
 
-# ------------------------------------------------------------------ agent commands
-
-
-@pytest.mark.parametrize(
-    "backend, expected_start",
-    [
-        ("opencode", ["opencode", "--print", "-m"]),
-        ("claude", ["claude", "--print"]),
-        ("gemini", ["gemini", "--yolo", "-p"]),
-        ("stub", ["sh", "-c"]),
-    ],
-)
-def test_agent_command_dispatch(backend, expected_start):
-    cmd = _agent_command(backend, "fix it")
-    assert cmd[: len(expected_start)] == expected_start
-
-
-def test_agent_command_unknown_backend_raises():
-    with pytest.raises(ValueError, match="Unknown backend"):
-        _agent_command("gpt-pilot", "fix it")
-
-
-def test_agent_command_stub_quotes_task():
-    cmd = _agent_command("stub", "task with 'quotes'")
-    # sh -c arg must safely contain the task
-    assert "task with" in cmd[-1]
-
-
 # ------------------------------------------------------------------ env vars
 
 
@@ -354,13 +327,4 @@ def test_empty_env_passes_no_secrets(mock_create):
     assert kwargs["secrets"] == []
 
 
-# ------------------------------------------------------------------ branch name
-
-
-def test_branch_name_format():
-    branch = _branch_name("opencode")
-    assert branch.startswith("agent/opencode-")
-    # timestamp portion: YYYYMMDD-HHMMSS
-    ts_part = branch[len("agent/opencode-"):]
-    assert len(ts_part) == 15
-    assert ts_part[8] == "-"
+# branch_name and agent command tests live in test_git_ops.py and test_backends.py

--- a/tests/unit/test_tester.py
+++ b/tests/unit/test_tester.py
@@ -1,0 +1,157 @@
+"""Unit tests for agent.tester — detection and result parsing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.tester import _parse_counts, detect_and_run
+
+
+def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout.read.return_value = stdout
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+def _make_sb(*procs: MagicMock) -> MagicMock:
+    """Return a sandbox mock whose exec calls return *procs* in order."""
+    sb = MagicMock()
+    sb.exec.side_effect = list(procs)
+    return sb
+
+
+# ------------------------------------------------------------------ no runner found
+
+
+def test_returns_none_when_no_runner_detected():
+    sb = _make_sb(_make_proc(stdout="none"))
+    assert detect_and_run(sb) is None
+
+
+# ------------------------------------------------------------------ pytest
+
+
+def test_detects_pytest_and_runs():
+    detect_proc = _make_proc(stdout="pytest")
+    test_proc = _make_proc(stdout="3 passed in 0.5s", returncode=0)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert result is not None
+    assert result.runner_name == "pytest"
+    assert result.passed == 3
+    assert result.failed == 0
+    assert result.success is True
+
+
+def test_pytest_with_failures():
+    detect_proc = _make_proc(stdout="pytest")
+    test_proc = _make_proc(stdout="2 passed, 1 failed in 0.8s", returncode=1)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert result.passed == 2
+    assert result.failed == 1
+    assert result.success is False
+
+
+def test_pytest_output_captured():
+    detect_proc = _make_proc(stdout="pytest")
+    test_proc = _make_proc(stdout="FAILED test_foo.py::test_bar\n1 failed", returncode=1)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert "test_foo" in result.output
+
+
+# ------------------------------------------------------------------ npm
+
+
+def test_detects_npm_and_runs():
+    detect_proc = _make_proc(stdout="npm")
+    test_proc = _make_proc(stdout="Tests: 5 passed, 0 failed", returncode=0)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert result.runner_name == "npm"
+    assert result.passed == 5
+    assert result.success is True
+
+
+# ------------------------------------------------------------------ cargo
+
+
+def test_detects_cargo_and_parses():
+    detect_proc = _make_proc(stdout="cargo")
+    test_proc = _make_proc(
+        stdout="test result: ok. 4 passed; 0 failed; 0 ignored",
+        returncode=0,
+    )
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert result.runner_name == "cargo"
+    assert result.passed == 4
+    assert result.failed == 0
+
+
+def test_cargo_with_failures():
+    detect_proc = _make_proc(stdout="cargo")
+    test_proc = _make_proc(
+        stdout="test result: FAILED. 2 passed; 1 failed; 0 ignored",
+        returncode=1,
+    )
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+    assert result.failed == 1
+    assert result.passed == 2
+
+
+# ------------------------------------------------------------------ go
+
+
+def test_detects_go_and_uses_exit_code():
+    detect_proc = _make_proc(stdout="go")
+    test_proc = _make_proc(stdout="ok  github.com/org/repo  0.003s", returncode=0)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+
+    assert result.runner_name == "go"
+    assert result.success is True
+
+
+def test_go_failure_uses_exit_code():
+    detect_proc = _make_proc(stdout="go")
+    test_proc = _make_proc(stdout="FAIL\tgithub.com/org/repo", returncode=1)
+    sb = _make_sb(detect_proc, test_proc)
+
+    result = detect_and_run(sb)
+    assert result.success is False
+
+
+# ------------------------------------------------------------------ _parse_counts
+
+
+@pytest.mark.parametrize("runner, output, exit_code, expected", [
+    ("pytest", "5 passed in 0.3s",          0, (5, 0)),
+    ("pytest", "3 passed, 2 failed in 0.5s", 1, (3, 2)),
+    ("pytest", "no output at all",           0, (1, 0)),
+    ("pytest", "no output at all",           1, (0, 1)),
+    ("npm",    "Tests: 4 passed, 1 failed",  1, (4, 1)),
+    ("cargo",  "3 passed; 1 failed; 0 ignored", 1, (3, 1)),
+    ("go",     "ok  github.com/...",         0, (1, 0)),
+    ("go",     "FAIL\t...",                  1, (0, 1)),
+])
+def test_parse_counts(runner, output, exit_code, expected):
+    assert _parse_counts(runner, output, exit_code) == expected


### PR DESCRIPTION
## Summary

Extracts all domain logic that was inline in `sandbox.py` into focused, independently testable modules. `sandbox.py` is now a thin orchestrator — it boots the container and sequences the steps, nothing more.

- **`agent/backends/`** — `AgentBackend` Protocol + `get_backend()` registry + 4 concrete backends (`opencode`, `claude`, `gemini`, `stub`). Each backend knows only its argv; fully decoupled from Modal SDK.
- **`agent/runner.py`** — `run_agent(sb, backend, task)` thin execution layer
- **`agent/tester.py`** — auto-detects pytest / npm / cargo / go; runs the suite; parses `SuiteResult`; falls back to exit code when counts can't be parsed
- **`agent/git_ops.py`** — `clone`, `collect_diff`, `push_and_pr`, `branch_name` extracted from `sandbox.py`; `push_and_pr` delegates to `sandbox.providers` for host-specific auth
- **`sandbox/spec.py`** — adds `run_tests: bool = True`
- **`sandbox/sandbox.py`** — orchestrator only; 199 lines of inline logic removed

## Test plan
- [x] 169 unit tests passing (`pytest -m unit`)
- [ ] Integration test on Modal: `pytest -m integration`

Closes #20, #21, #22, #7, #8, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)