### PR TITLE
feat(dashboard): live run dashboard with SSE streaming

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,17 @@
+"""FastAPI application entry-point for the agent-container dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from dashboard.router import router
+
+app = FastAPI(title="agent-container dashboard", version="0.1.0")
+
+app.include_router(router, prefix="/api")
+
+_STATIC_DIR = Path(__file__).parent / "static"
+app.mount("/", StaticFiles(directory=_STATIC_DIR, html=True), name="static")

--- a/dashboard/router.py
+++ b/dashboard/router.py
@@ -1,0 +1,138 @@
+"""FastAPI router for the agent-container dashboard.
+
+Routes
+------
+GET  /runs              — list all runs (summary, no events)
+POST /runs              — start a new run in a background thread
+GET  /runs/{id}         — get a single run (summary)
+DELETE /runs/{id}        — cancel a queued/running run (best-effort)
+GET  /runs/{id}/stream  — SSE stream of lifecycle events
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from dashboard.store import WorkspaceStore
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox
+from sandbox.spec import AgentTaskSpec
+
+router = APIRouter()
+
+# Module-level singletons shared between router functions and injected into tests.
+store = WorkspaceStore()
+_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="sandbox")
+_futures: dict[str, Future] = {}  # run_id → Future for cancellation
+
+
+# ------------------------------------------------------------------ request model
+
+
+class StartRunRequest(BaseModel):
+    repo: str
+    task: str
+    backend: str = "opencode"
+    base_branch: str = "main"
+    create_pr: bool = True
+    run_tests: bool = True
+    timeout_seconds: int = 300
+
+
+# ------------------------------------------------------------------ routes
+
+
+@router.get("/runs")
+def list_runs() -> list[dict[str, Any]]:
+    return [r.to_dict() for r in store.list_runs()]
+
+
+@router.post("/runs", status_code=202)
+def start_run(body: StartRunRequest) -> dict[str, str]:
+    run_id = uuid.uuid4().hex[:12]
+
+    store.create_run(
+        run_id=run_id,
+        repo=body.repo,
+        task=body.task,
+        backend=body.backend,
+    )
+
+    def _run() -> None:
+        def on_event(event_type: str, payload: dict) -> None:
+            store.push_event(run_id, event_type, payload)
+
+        spec = AgentTaskSpec(
+            repo=body.repo,
+            task=body.task,
+            backend=body.backend,
+            base_branch=body.base_branch,
+            create_pr=body.create_pr,
+            run_tests=body.run_tests,
+            timeout_seconds=body.timeout_seconds,
+        )
+        config = SandboxConfig()
+        ModalSandbox(config).run(spec, on_event=on_event)
+
+    future = _executor.submit(_run)
+    _futures[run_id] = future
+    return {"run_id": run_id}
+
+
+@router.get("/runs/{run_id}")
+def get_run(run_id: str) -> dict[str, Any]:
+    state = store.get_run(run_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return state.to_dict()
+
+
+@router.delete("/runs/{run_id}", status_code=204)
+def cancel_run(run_id: str) -> None:
+    future = _futures.get(run_id)
+    if future is not None:
+        future.cancel()  # no-op if already running, but worth trying
+    state = store.get_run(run_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    # Mark terminal so SSE clients disconnect.
+    store.push_event(run_id, "done", {"success": False, "error": "cancelled"})
+
+
+@router.get("/runs/{run_id}/stream")
+async def stream_run(run_id: str) -> StreamingResponse:
+    state = store.get_run(run_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="run not found")
+
+    async def _generate():
+        cursor = 0
+        while True:
+            events = store.events_from(run_id, cursor)
+            for event in events:
+                # Filter out the result object (not JSON-serialisable as-is).
+                safe = {k: v for k, v in event.items() if k != "result"}
+                yield f"data: {json.dumps(safe)}\n\n"
+            cursor += len(events)
+
+            if store.is_terminal(run_id) and not store.events_from(run_id, cursor):
+                break
+
+            await asyncio.sleep(0.2)
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>agent-container dashboard</title>
+  <style>
+    /* --------------------------------------------------------- reset & base */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:      #0d1117;
+      --surface: #161b22;
+      --border:  #30363d;
+      --text:    #e6edf3;
+      --muted:   #8b949e;
+      --accent:  #58a6ff;
+      --green:   #3fb950;
+      --red:     #f85149;
+      --yellow:  #d29922;
+      --purple:  #bc8cff;
+      --mono:    "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    /* --------------------------------------------------------- layout */
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 { font-size: 15px; font-weight: 600; color: var(--text); }
+    header span { font-size: 11px; color: var(--muted); }
+
+    main {
+      display: grid;
+      grid-template-columns: 340px 1fr;
+      gap: 0;
+      height: calc(100vh - 49px);
+    }
+
+    /* --------------------------------------------------------- sidebar */
+    #sidebar {
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+    }
+
+    #new-run-form {
+      padding: 16px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    #new-run-form h2 { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; }
+
+    label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 2px; }
+
+    input, select, textarea {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+      padding: 6px 8px;
+      outline: none;
+      font-family: inherit;
+      resize: vertical;
+    }
+
+    input:focus, select:focus, textarea:focus {
+      border-color: var(--accent);
+    }
+
+    #start-btn {
+      background: var(--accent);
+      color: #000;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 8px 14px;
+      cursor: pointer;
+      margin-top: 4px;
+    }
+
+    #start-btn:hover { opacity: .88; }
+    #start-btn:disabled { opacity: .4; cursor: not-allowed; }
+
+    /* --------------------------------------------------------- run list */
+    #run-list { flex: 1; overflow-y: auto; }
+
+    .run-card {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      transition: background .1s;
+    }
+
+    .run-card:hover  { background: rgba(88,166,255,.06); }
+    .run-card.active { background: rgba(88,166,255,.10); border-left: 2px solid var(--accent); }
+
+    .run-card-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 2px;
+    }
+
+    .phase-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .phase-dot.BOOTING  { background: var(--yellow); animation: pulse 1s infinite; }
+    .phase-dot.CLONING  { background: var(--yellow); animation: pulse 1s infinite; }
+    .phase-dot.RUNNING  { background: var(--accent);  animation: pulse 1s infinite; }
+    .phase-dot.TESTING  { background: var(--purple);  animation: pulse 1s infinite; }
+    .phase-dot.PR       { background: var(--purple);  animation: pulse 1s infinite; }
+    .phase-dot.DONE     { background: var(--green); }
+    .phase-dot.FAILED   { background: var(--red); }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: .35; }
+    }
+
+    .run-id { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+    .run-repo { font-size: 12px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .run-phase { font-size: 11px; color: var(--muted); }
+
+    /* --------------------------------------------------------- detail panel */
+    #detail {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    #detail-header {
+      padding: 16px 20px 12px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    #detail-header .repo-link {
+      color: var(--accent);
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    #detail-header .repo-link:hover { text-decoration: underline; }
+
+    #detail-meta {
+      display: flex;
+      gap: 16px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    #detail-meta .badge {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 7px;
+      font-family: var(--mono);
+      font-size: 11px;
+    }
+
+    #pr-link {
+      display: inline-block;
+      background: var(--green);
+      color: #000;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 3px 10px;
+      border-radius: 4px;
+      text-decoration: none;
+    }
+
+    #pr-link:hover { opacity: .85; }
+    #pr-link.hidden { display: none; }
+
+    #log-area {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.55;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: var(--text);
+      background: var(--bg);
+    }
+
+    .log-line { }
+    .log-phase { color: var(--accent); font-weight: 700; }
+    .log-done-ok   { color: var(--green); font-weight: 700; }
+    .log-done-fail { color: var(--red);   font-weight: 700; }
+    .log-ts { color: var(--muted); user-select: none; margin-right: 8px; }
+
+    /* --------------------------------------------------------- empty state */
+    #empty {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: var(--muted);
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>agent-container</h1>
+  <span>dashboard</span>
+</header>
+
+<main>
+  <!-- ------------------------------------------------ sidebar -->
+  <div id="sidebar">
+    <form id="new-run-form" onsubmit="return false">
+      <h2>New run</h2>
+      <div>
+        <label for="inp-repo">Repo URL</label>
+        <input id="inp-repo" type="url" placeholder="https://github.com/org/repo" required />
+      </div>
+      <div>
+        <label for="inp-task">Task</label>
+        <textarea id="inp-task" rows="3" placeholder="Describe what the agent should do…" required></textarea>
+      </div>
+      <div>
+        <label for="inp-backend">Backend</label>
+        <select id="inp-backend">
+          <option value="opencode">opencode</option>
+          <option value="claude">claude</option>
+          <option value="gemini">gemini</option>
+          <option value="stub">stub</option>
+        </select>
+      </div>
+      <div>
+        <label for="inp-branch">Base branch</label>
+        <input id="inp-branch" type="text" value="main" />
+      </div>
+      <div style="display:flex;gap:12px;align-items:center;">
+        <label style="display:flex;align-items:center;gap:4px;margin:0">
+          <input id="inp-pr" type="checkbox" checked /> Create PR
+        </label>
+        <label style="display:flex;align-items:center;gap:4px;margin:0">
+          <input id="inp-tests" type="checkbox" checked /> Run tests
+        </label>
+      </div>
+      <button id="start-btn" type="button" onclick="startRun()">Start run</button>
+    </form>
+
+    <div id="run-list"></div>
+  </div>
+
+  <!-- ------------------------------------------------ detail -->
+  <div id="detail">
+    <div id="empty">Select a run or start one →</div>
+  </div>
+</main>
+
+<script>
+// ------------------------------------------------------------------ state
+const runs = {};       // run_id → { state, card el, sse }
+let activeRunId = null;
+
+// ------------------------------------------------------------------ API helpers
+async function apiPost(path, body) {
+  const r = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+// ------------------------------------------------------------------ start run
+async function startRun() {
+  const repo  = document.getElementById('inp-repo').value.trim();
+  const task  = document.getElementById('inp-task').value.trim();
+  if (!repo || !task) return;
+
+  const btn = document.getElementById('start-btn');
+  btn.disabled = true;
+
+  try {
+    const { run_id } = await apiPost('/api/runs', {
+      repo,
+      task,
+      backend:         document.getElementById('inp-backend').value,
+      base_branch:     document.getElementById('inp-branch').value || 'main',
+      create_pr:       document.getElementById('inp-pr').checked,
+      run_tests:       document.getElementById('inp-tests').checked,
+      timeout_seconds: 300,
+    });
+    addRun(run_id, repo, task, document.getElementById('inp-backend').value);
+    openRun(run_id);
+  } catch (e) {
+    alert('Failed to start run: ' + e.message);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+// ------------------------------------------------------------------ run card
+function addRun(run_id, repo, task, backend) {
+  const card = document.createElement('div');
+  card.className = 'run-card';
+  card.dataset.runId = run_id;
+  card.innerHTML = `
+    <div class="run-card-header">
+      <div class="phase-dot BOOTING" id="dot-${run_id}"></div>
+      <span class="run-id">${run_id}</span>
+    </div>
+    <div class="run-repo">${escHtml(repo)}</div>
+    <div class="run-phase" id="phase-label-${run_id}">BOOTING</div>
+  `;
+  card.onclick = () => openRun(run_id);
+  document.getElementById('run-list').prepend(card);
+
+  runs[run_id] = { repo, task, backend, phase: 'BOOTING', card, logLines: [] };
+}
+
+function updateCard(run_id, phase) {
+  const r = runs[run_id];
+  if (!r) return;
+  r.phase = phase;
+  const dot = document.getElementById('dot-' + run_id);
+  if (dot) {
+    dot.className = `phase-dot ${phase}`;
+  }
+  const label = document.getElementById('phase-label-' + run_id);
+  if (label) label.textContent = phase;
+  if (r.card) {
+    r.card.className = 'run-card' + (activeRunId === run_id ? ' active' : '');
+  }
+}
+
+// ------------------------------------------------------------------ detail panel
+function openRun(run_id) {
+  if (activeRunId === run_id) return;
+
+  // Deactivate old card
+  if (activeRunId && runs[activeRunId]) {
+    runs[activeRunId].card.classList.remove('active');
+  }
+
+  activeRunId = run_id;
+  const r = runs[run_id];
+  r.card.classList.add('active');
+
+  const detail = document.getElementById('detail');
+  detail.innerHTML = `
+    <div id="detail-header">
+      <a class="repo-link" href="${escHtml(r.repo)}" target="_blank">${escHtml(r.repo)}</a>
+      <div id="detail-meta">
+        <span class="badge">${escHtml(r.backend)}</span>
+        <span id="detail-phase">${r.phase}</span>
+        <a id="pr-link" class="hidden" href="#" target="_blank">Open PR</a>
+      </div>
+      <div style="font-size:12px;color:var(--muted);margin-top:4px">${escHtml(r.task)}</div>
+    </div>
+    <div id="log-area"></div>
+  `;
+
+  // Replay buffered log lines
+  const logArea = document.getElementById('log-area');
+  for (const line of r.logLines) {
+    logArea.appendChild(line.cloneNode(true));
+  }
+  logArea.scrollTop = logArea.scrollHeight;
+
+  // Subscribe to SSE if not already
+  if (!r.sse && !isTerminal(r.phase)) {
+    subscribeSSE(run_id);
+  }
+}
+
+function isTerminal(phase) {
+  return phase === 'DONE' || phase === 'FAILED';
+}
+
+// ------------------------------------------------------------------ SSE
+function subscribeSSE(run_id) {
+  const r = runs[run_id];
+  if (!r) return;
+
+  const sse = new EventSource(`/api/runs/${run_id}/stream`);
+  r.sse = sse;
+
+  sse.onmessage = (e) => {
+    let ev;
+    try { ev = JSON.parse(e.data); } catch { return; }
+    handleEvent(run_id, ev);
+  };
+
+  sse.onerror = () => {
+    sse.close();
+    r.sse = null;
+  };
+}
+
+function handleEvent(run_id, ev) {
+  const r = runs[run_id];
+  if (!r) return;
+
+  const ts = new Date(ev.ts * 1000).toLocaleTimeString('en-US', { hour12: false });
+
+  if (ev.type === 'phase') {
+    updateCard(run_id, ev.phase);
+    if (activeRunId === run_id) {
+      const el = document.getElementById('detail-phase');
+      if (el) el.textContent = ev.phase;
+    }
+    appendLog(run_id, ts, `▶ ${ev.phase}`, 'log-phase');
+
+  } else if (ev.type === 'log') {
+    appendLog(run_id, ts, ev.text || '', 'log-line');
+
+  } else if (ev.type === 'done') {
+    const phase = ev.success ? 'DONE' : 'FAILED';
+    updateCard(run_id, phase);
+
+    if (activeRunId === run_id) {
+      const el = document.getElementById('detail-phase');
+      if (el) el.textContent = phase;
+
+      if (ev.pr_url) {
+        const link = document.getElementById('pr-link');
+        if (link) {
+          link.href = ev.pr_url;
+          link.textContent = 'Open PR →';
+          link.classList.remove('hidden');
+        }
+      }
+    }
+
+    const cls = ev.success ? 'log-done-ok' : 'log-done-fail';
+    const msg = ev.success
+      ? `✓ DONE${ev.diff_stat ? '  ' + ev.diff_stat : ''}`
+      : `✗ FAILED${ev.error ? '  ' + ev.error : ''}`;
+    appendLog(run_id, ts, msg, cls);
+
+    if (r.sse) { r.sse.close(); r.sse = null; }
+  }
+}
+
+function appendLog(run_id, ts, text, cls) {
+  const r = runs[run_id];
+  if (!r) return;
+
+  const span = document.createElement('div');
+  span.className = cls;
+  span.innerHTML = `<span class="log-ts">${escHtml(ts)}</span>${escHtml(text)}`;
+  r.logLines.push(span);
+
+  if (activeRunId === run_id) {
+    const logArea = document.getElementById('log-area');
+    if (logArea) {
+      logArea.appendChild(span.cloneNode(true));
+      logArea.scrollTop = logArea.scrollHeight;
+    }
+  }
+}
+
+// ------------------------------------------------------------------ utils
+function escHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ------------------------------------------------------------------ boot — load existing runs
+(async () => {
+  try {
+    const list = await fetch('/api/runs').then(r => r.json());
+    for (const run of list.reverse()) {
+      addRun(run.run_id, run.repo, run.task || '', run.backend || 'opencode');
+      updateCard(run.run_id, run.phase);
+    }
+  } catch { /* dashboard works offline */ }
+})();
+</script>
+</body>
+</html>

--- a/dashboard/store.py
+++ b/dashboard/store.py
@@ -1,0 +1,102 @@
+"""In-memory run store for the dashboard.
+
+WorkspaceStore is a thread-safe registry that accumulates events emitted by
+ModalSandbox.run() via the on_event callback.  The SSE router polls it with
+cursor-based reads so no asyncio queues or call_soon_threadsafe are needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from sandbox.result import AgentTaskResult
+
+
+# Phases in lifecycle order.  The store auto-advances phase on well-known events.
+PHASES = ["BOOTING", "CLONING", "RUNNING", "TESTING", "PR", "DONE", "FAILED"]
+
+
+@dataclass
+class RunState:
+    """All state for a single agent run."""
+
+    run_id: str
+    repo: str
+    task: str
+    backend: str
+    phase: str = "BOOTING"
+    started_at: float = field(default_factory=time.time)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    result: AgentTaskResult | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "repo": self.repo,
+            "task": self.task,
+            "backend": self.backend,
+            "phase": self.phase,
+            "started_at": self.started_at,
+            "result": self.result.to_dict() if self.result else None,
+        }
+
+
+class WorkspaceStore:
+    """Thread-safe store for all active and completed runs."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._runs: dict[str, RunState] = {}
+
+    # ------------------------------------------------------------------ write
+
+    def create_run(self, run_id: str, repo: str, task: str, backend: str) -> RunState:
+        state = RunState(run_id=run_id, repo=repo, task=task, backend=backend)
+        with self._lock:
+            self._runs[run_id] = state
+        return state
+
+    def push_event(self, run_id: str, event_type: str, payload: dict[str, Any]) -> None:
+        """Append an event and update phase if the event carries one."""
+        event = {"type": event_type, "ts": time.time(), **payload}
+        with self._lock:
+            state = self._runs.get(run_id)
+            if state is None:
+                return
+            state.events.append(event)
+            # Advance phase automatically for well-known phase events.
+            if event_type == "phase" and payload.get("phase") in PHASES:
+                state.phase = payload["phase"]
+            elif event_type == "done":
+                state.phase = "DONE" if payload.get("success") else "FAILED"
+                # Persist result summary on the state for the /runs list.
+                if "result" in payload:
+                    state.result = payload["result"]
+
+    # ------------------------------------------------------------------ read
+
+    def get_run(self, run_id: str) -> RunState | None:
+        with self._lock:
+            return self._runs.get(run_id)
+
+    def list_runs(self) -> list[RunState]:
+        with self._lock:
+            return list(self._runs.values())
+
+    def events_from(self, run_id: str, cursor: int) -> list[dict[str, Any]]:
+        """Return events at index >= cursor.  Safe to call from any thread."""
+        with self._lock:
+            state = self._runs.get(run_id)
+            if state is None:
+                return []
+            return state.events[cursor:]
+
+    def is_terminal(self, run_id: str) -> bool:
+        with self._lock:
+            state = self._runs.get(run_id)
+            if state is None:
+                return True
+            return state.phase in ("DONE", "FAILED")

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections.abc import Callable
 
 import modal
 from agent import git_ops, runner, tester
@@ -50,21 +51,46 @@ class ModalSandbox:
 
     # ------------------------------------------------------------------ public
 
-    def run(self, spec: AgentTaskSpec) -> AgentTaskResult:
+    def run(
+        self,
+        spec: AgentTaskSpec,
+        on_event: Callable[[str, dict], None] | None = None,
+    ) -> AgentTaskResult:
+        """Run the agent pipeline.
+
+        Args:
+            spec: Task specification.
+            on_event: Optional callback invoked as ``on_event(event_type, payload)``
+                      at each lifecycle transition.  Used by the dashboard to stream
+                      progress without coupling sandbox logic to FastAPI.
+        """
+        def _emit(event_type: str, **payload) -> None:
+            if on_event is not None:
+                try:
+                    on_event(event_type, payload)
+                except Exception:
+                    pass  # never let dashboard callbacks crash the run
+
         start = time.monotonic()
         sb: modal.Sandbox | None = None
         # Unique app per run — avoids collisions when multiple runs execute in parallel.
         app = modal.App.lookup(f"agent-container-{uuid.uuid4().hex[:8]}", create_if_missing=True)
         try:
             try:
+                _emit("phase", phase="BOOTING")
                 sb = self._create(spec, app)
+
+                _emit("phase", phase="CLONING")
                 git_ops.clone(sb, spec.repo, spec.base_branch)
 
+                _emit("phase", phase="RUNNING")
                 backend = get_backend(spec.backend)
                 agent_output, exit_code = runner.run_agent(sb, backend, spec.resolved_task())
+                _emit("log", text=agent_output)
 
                 suite: SuiteResult | None = None
                 if exit_code == 0 and spec.run_tests:
+                    _emit("phase", phase="TESTING")
                     suite = tester.detect_and_run(sb)
 
                 diff, diff_stat = git_ops.collect_diff(sb)
@@ -72,6 +98,7 @@ class ModalSandbox:
                 branch: str | None = None
                 pr_url: str | None = None
                 if exit_code == 0 and diff and spec.create_pr:
+                    _emit("phase", phase="PR")
                     branch, pr_url = git_ops.push_and_pr(
                         sb,
                         repo=spec.repo,
@@ -82,15 +109,17 @@ class ModalSandbox:
                     )
 
             except Exception as exc:
-                return AgentTaskResult(
+                result = AgentTaskResult(
                     success=False,
                     run_id=_run_id(sb),
                     duration_seconds=time.monotonic() - start,
                     error=str(exc),
                     backend=spec.backend,
                 )
+                _emit("done", success=False, error=str(exc), result=result)
+                return result
 
-            return AgentTaskResult(
+            result = AgentTaskResult(
                 success=exit_code == 0,
                 run_id=_run_id(sb),
                 branch=branch,
@@ -102,6 +131,15 @@ class ModalSandbox:
                 error=None if exit_code == 0 else agent_output,
                 backend=spec.backend,
             )
+            _emit(
+                "done",
+                success=result.success,
+                pr_url=pr_url,
+                diff_stat=diff_stat,
+                error=result.error,
+                result=result,
+            )
+            return result
         finally:
             # Always terminate — even on KeyboardInterrupt or other BaseException.
             _terminate(sb)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,0 +1,173 @@
+"""Unit tests for dashboard.store — WorkspaceStore and RunState."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dashboard.store import WorkspaceStore
+
+
+# ------------------------------------------------------------------ helpers
+
+
+def _store() -> WorkspaceStore:
+    return WorkspaceStore()
+
+
+def _create(store: WorkspaceStore, run_id: str = "run-001") -> None:
+    store.create_run(run_id=run_id, repo="https://github.com/org/repo", task="fix it", backend="opencode")
+
+
+# ------------------------------------------------------------------ create / get / list
+
+
+def test_create_and_get_run():
+    s = _store()
+    _create(s)
+    state = s.get_run("run-001")
+    assert state is not None
+    assert state.run_id == "run-001"
+    assert state.phase == "BOOTING"
+    assert state.events == []
+
+
+def test_get_missing_run_returns_none():
+    s = _store()
+    assert s.get_run("nope") is None
+
+
+def test_list_runs_empty():
+    assert _store().list_runs() == []
+
+
+def test_list_runs_returns_all():
+    s = _store()
+    _create(s, "r1")
+    _create(s, "r2")
+    ids = {r.run_id for r in s.list_runs()}
+    assert ids == {"r1", "r2"}
+
+
+# ------------------------------------------------------------------ push_event / phase transitions
+
+
+def test_push_phase_event_updates_phase():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "phase", {"phase": "CLONING"})
+    assert s.get_run("run-001").phase == "CLONING"
+
+
+def test_push_done_success_sets_done():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "done", {"success": True})
+    assert s.get_run("run-001").phase == "DONE"
+
+
+def test_push_done_failure_sets_failed():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "done", {"success": False})
+    assert s.get_run("run-001").phase == "FAILED"
+
+
+def test_push_log_event_appended():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "log", {"text": "hello"})
+    events = s.events_from("run-001", 0)
+    assert len(events) == 1
+    assert events[0]["type"] == "log"
+    assert events[0]["text"] == "hello"
+
+
+def test_push_to_missing_run_is_noop():
+    s = _store()
+    s.push_event("ghost", "log", {"text": "irrelevant"})  # should not raise
+
+
+def test_event_has_ts_field():
+    s = _store()
+    _create(s)
+    before = time.time()
+    s.push_event("run-001", "log", {"text": "x"})
+    after = time.time()
+    ts = s.events_from("run-001", 0)[0]["ts"]
+    assert before <= ts <= after
+
+
+# ------------------------------------------------------------------ events_from cursor
+
+
+def test_events_from_cursor_zero_returns_all():
+    s = _store()
+    _create(s)
+    for i in range(5):
+        s.push_event("run-001", "log", {"text": str(i)})
+    assert len(s.events_from("run-001", 0)) == 5
+
+
+def test_events_from_cursor_advances():
+    s = _store()
+    _create(s)
+    for i in range(4):
+        s.push_event("run-001", "log", {"text": str(i)})
+    batch1 = s.events_from("run-001", 0)
+    batch2 = s.events_from("run-001", len(batch1))
+    assert batch2 == []
+    # Add more
+    s.push_event("run-001", "log", {"text": "new"})
+    batch3 = s.events_from("run-001", len(batch1))
+    assert len(batch3) == 1
+    assert batch3[0]["text"] == "new"
+
+
+def test_events_from_missing_run_returns_empty():
+    assert _store().events_from("ghost", 0) == []
+
+
+# ------------------------------------------------------------------ is_terminal
+
+
+def test_is_terminal_booting_false():
+    s = _store()
+    _create(s)
+    assert s.is_terminal("run-001") is False
+
+
+def test_is_terminal_done_true():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "done", {"success": True})
+    assert s.is_terminal("run-001") is True
+
+
+def test_is_terminal_failed_true():
+    s = _store()
+    _create(s)
+    s.push_event("run-001", "done", {"success": False})
+    assert s.is_terminal("run-001") is True
+
+
+def test_is_terminal_missing_run_true():
+    """Missing runs are treated as terminal so SSE clients disconnect."""
+    assert _store().is_terminal("ghost") is True
+
+
+# ------------------------------------------------------------------ to_dict
+
+
+def test_to_dict_has_expected_keys():
+    s = _store()
+    _create(s)
+    d = s.get_run("run-001").to_dict()
+    assert d["run_id"] == "run-001"
+    assert d["repo"] == "https://github.com/org/repo"
+    assert d["task"] == "fix it"
+    assert d["backend"] == "opencode"
+    assert d["phase"] == "BOOTING"
+    assert "started_at" in d
+    assert d["result"] is None


### PR DESCRIPTION
## Summary

- **`dashboard/store.py`** — thread-safe `WorkspaceStore` with cursor-based event reads and `RunState` dataclass
- **`dashboard/router.py`** — FastAPI routes: `GET/POST/DELETE /api/runs`, SSE `/api/runs/{id}/stream` (200ms poll, no asyncio queues)
- **`dashboard/app.py`** — app entry-point, mounts router + static files
- **`dashboard/static/index.html`** — dark terminal UI with `EventSource` live updates, phase dots, log stream, PR link
- **`sandbox/sandbox.py`** — `on_event` callback emits `phase`/`log`/`done` events; errors swallowed so dashboard can never crash a run
- **`tests/unit/test_store.py`** — 18 store unit tests (187 total, all passing)

Closes #10, #11, #12

## Test plan

- [x] All 187 unit tests pass (`python3 -m pytest tests/unit/ -v`)
- [ ] Start server: `uvicorn dashboard.app:app --reload`
- [ ] Open `http://localhost:8000`, submit a run, watch phase dot animate and log stream update live
- [ ] Verify PR link appears when agent produces a diff with `create_pr=true`
- [ ] Verify `DELETE /api/runs/{id}` closes the SSE stream on the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)