### PR TITLE
feat(mcp): MCP server with sandbox_run/list/status/stop tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "agent-container": {
+      "command": "python3",
+      "args": ["-m", "mcp_server.server"],
+      "env": {
+        "MODAL_TOKEN_ID": "",
+        "MODAL_TOKEN_SECRET": "",
+        "GITHUB_TOKEN": "",
+        "GITLAB_TOKEN": "",
+        "OPENAI_BASE_URL": "",
+        "OPENAI_API_KEY": ""
+      }
+    }
+  }
+}

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "agent-container": {
+      "command": "python3",
+      "args": ["-m", "mcp_server.server"],
+      "env": {
+        "MODAL_TOKEN_ID": "",
+        "MODAL_TOKEN_SECRET": "",
+        "GITHUB_TOKEN": "",
+        "GITLAB_TOKEN": "",
+        "OPENAI_BASE_URL": "",
+        "OPENAI_API_KEY": ""
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test lint mcp dashboard
+
+test:
+	python3 -m pytest tests/unit/ -v
+
+lint:
+	python3 -m ruff check .
+
+mcp:
+	python3 -m mcp_server.server --transport stdio
+
+dashboard:
+	python3 -m uvicorn dashboard.app:app --reload --port 8000

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,3 @@
+from mcp_server.server import main
+
+main()

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,202 @@
+"""MCP server exposing agent-container sandbox tools.
+
+Four tools are registered:
+
+  sandbox_run    — boot a Modal sandbox, run an AI agent, return the result
+  sandbox_list   — list all runs tracked in the WorkspaceStore
+  sandbox_status — get the state + buffered events for a specific run
+  sandbox_stop   — cancel a running sandbox
+
+The server integrates with the dashboard WorkspaceStore so tool calls and
+dashboard HTTP clients share the same in-memory state when both are running.
+When the server is started standalone (python -m mcp_server.server) the store
+starts empty; it is NOT pre-populated from a separate dashboard process.
+
+Run modes
+---------
+stdio (default, for Claude Code / Gemini CLI):
+    python -m mcp_server.server
+
+SSE (for remote / multi-client use):
+    python -m mcp_server.server --transport sse --port 8001
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from fastmcp import FastMCP
+
+from dashboard.store import WorkspaceStore
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox
+from sandbox.spec import AgentTaskSpec
+
+mcp = FastMCP(
+    "agent-container",
+    instructions=(
+        "Tools to run AI coding agents in ephemeral Modal sandboxes. "
+        "Use sandbox_run to kick off a task, sandbox_status to poll progress, "
+        "sandbox_list to see all runs, and sandbox_stop to cancel."
+    ),
+)
+
+# Shared state — also importable by the dashboard so they can share a store.
+store = WorkspaceStore()
+_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="mcp-sandbox")
+_futures: dict[str, Any] = {}
+
+
+# ------------------------------------------------------------------ tools
+
+
+@mcp.tool()
+async def sandbox_run(
+    task: str,
+    repo: str,
+    base_branch: str = "main",
+    backend: str = "opencode",
+    create_pr: bool = True,
+    run_tests: bool = True,
+    timeout_seconds: int = 300,
+    image: str | None = None,
+) -> dict:
+    """Boot an ephemeral Modal sandbox, run an AI coding agent on the task, and return the result.
+
+    Args:
+        task: Plain-English description of what the agent should do.
+        repo: Full GitHub or GitLab URL (https:// or git@).
+        base_branch: Branch to clone and base any PR on. Defaults to "main".
+        backend: Agent backend — "opencode" (default), "claude", "gemini", or "stub".
+        create_pr: Whether to open a pull/merge request when the agent produces a diff.
+        run_tests: Whether to auto-detect and run the project test suite after the agent.
+        timeout_seconds: Hard sandbox timeout. Defaults to 300 s.
+        image: Optional Docker image override; defaults to the base agent image.
+
+    Returns:
+        AgentTaskResult as a dict with keys: success, run_id, branch, pr_url,
+        diff_stat, tests, duration_seconds, error, backend.
+    """
+    run_id = uuid.uuid4().hex[:12]
+    store.create_run(run_id=run_id, repo=repo, task=task, backend=backend)
+
+    def _on_event(event_type: str, payload: dict) -> None:
+        store.push_event(run_id, event_type, payload)
+
+    def _run() -> dict:
+        spec_kwargs: dict[str, Any] = dict(
+            repo=repo,
+            task=task,
+            base_branch=base_branch,
+            backend=backend,
+            create_pr=create_pr,
+            run_tests=run_tests,
+            timeout_seconds=timeout_seconds,
+        )
+        if image:
+            spec_kwargs["image"] = image
+
+        spec = AgentTaskSpec(**spec_kwargs)
+        config = SandboxConfig()
+        result = ModalSandbox(config).run(spec, on_event=_on_event)
+        # Omit full diff from MCP response — it can be very large.
+        # Use our generated run_id (not Modal's sandbox object_id).
+        d = result.to_dict()
+        d.pop("diff", None)
+        d.pop("run_id", None)
+        return d
+
+    # Run blocking sandbox code in thread pool so the MCP event loop stays free.
+    future = _executor.submit(_run)
+    _futures[run_id] = future
+    result_dict = await asyncio.get_event_loop().run_in_executor(None, future.result)
+    return {"run_id": run_id, **result_dict}
+
+
+@mcp.tool()
+async def sandbox_list() -> list[dict]:
+    """List all agent runs — active, completed, and failed.
+
+    Returns a summary list (no event log) sorted newest-first by start time.
+    """
+    runs = store.list_runs()
+    runs.sort(key=lambda r: r.started_at, reverse=True)
+    return [r.to_dict() for r in runs]
+
+
+@mcp.tool()
+async def sandbox_status(run_id: str) -> dict:
+    """Get the current state and buffered event log for a specific run.
+
+    Args:
+        run_id: The run ID returned by sandbox_run.
+
+    Returns:
+        Run state dict plus an "events" list with all buffered lifecycle events.
+    """
+    state = store.get_run(run_id)
+    if state is None:
+        return {"error": f"run {run_id!r} not found"}
+    d = state.to_dict()
+    # Include safe subset of events (no embedded AgentTaskResult objects).
+    d["events"] = [
+        {k: v for k, v in ev.items() if k != "result"}
+        for ev in store.events_from(run_id, 0)
+    ]
+    return d
+
+
+@mcp.tool()
+async def sandbox_stop(run_id: str) -> dict:
+    """Cancel a running sandbox and mark it as failed.
+
+    Args:
+        run_id: The run ID to stop.
+
+    Returns:
+        {"run_id": ..., "cancelled": true} or an error dict.
+    """
+    state = store.get_run(run_id)
+    if state is None:
+        return {"error": f"run {run_id!r} not found"}
+
+    future = _futures.get(run_id)
+    if future is not None:
+        future.cancel()
+
+    store.push_event(run_id, "done", {"success": False, "error": "cancelled by sandbox_stop"})
+    return {"run_id": run_id, "cancelled": True}
+
+
+# ------------------------------------------------------------------ entry point
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="agent-container MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse"],
+        default="stdio",
+        help="Transport mode (default: stdio)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8001,
+        help="Port for SSE transport (default: 8001)",
+    )
+    args = parser.parse_args()
+
+    if args.transport == "sse":
+        mcp.run(transport="sse", host="0.0.0.0", port=args.port)
+    else:
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["sandbox", "agent", "dashboard", "mcp"]
+packages = ["sandbox", "agent", "dashboard", "mcp_server"]
 
 [project]
 name = "agent-container"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,228 @@
+"""Unit tests for mcp_server.server — all Modal + sandbox calls mocked."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mcp_server.server as srv
+from dashboard.store import WorkspaceStore
+from sandbox.result import AgentTaskResult
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+@pytest.fixture(autouse=True)
+def fresh_store(monkeypatch):
+    """Give each test an isolated WorkspaceStore."""
+    s = WorkspaceStore()
+    monkeypatch.setattr(srv, "store", s)
+    monkeypatch.setattr(srv, "_futures", {})
+    return s
+
+
+def _ok_result(run_id: str = "abc123") -> AgentTaskResult:
+    return AgentTaskResult(
+        success=True,
+        run_id=run_id,
+        branch="agent/opencode-20260424-120000",
+        pr_url="https://github.com/org/repo/pull/7",
+        diff="diff --git a/f b/f\n+fix",
+        diff_stat="1 file changed",
+        backend="opencode",
+        duration_seconds=12.3,
+    )
+
+
+def _fail_result(run_id: str = "abc123") -> AgentTaskResult:
+    return AgentTaskResult(
+        success=False,
+        run_id=run_id,
+        error="agent crashed",
+        backend="opencode",
+        duration_seconds=3.1,
+    )
+
+
+# ------------------------------------------------------------------ sandbox_run
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_returns_result_dict(fresh_store):
+    result = _ok_result()
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.return_value = result
+        out = await srv.sandbox_run(task="fix it", repo="https://github.com/org/repo")
+
+    assert out["success"] is True
+    assert out["pr_url"] == "https://github.com/org/repo/pull/7"
+    assert out["diff_stat"] == "1 file changed"
+    # Full diff is stripped from MCP response (can be very large)
+    assert "diff" not in out
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_omits_diff_from_response(fresh_store):
+    result = _ok_result()
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.return_value = result
+        out = await srv.sandbox_run(task="task", repo="https://github.com/org/repo")
+
+    assert "diff" not in out
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_records_run_in_store(fresh_store):
+    result = _ok_result()
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.return_value = result
+        out = await srv.sandbox_run(task="fix it", repo="https://github.com/org/repo")
+
+    run_id = out["run_id"]
+    assert fresh_store.get_run(run_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_failure_returns_success_false(fresh_store):
+    result = _fail_result()
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.return_value = result
+        out = await srv.sandbox_run(task="fix it", repo="https://github.com/org/repo")
+
+    assert out["success"] is False
+    assert out["error"] == "agent crashed"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_forwards_backend_to_spec(fresh_store):
+    result = _ok_result()
+    captured = {}
+
+    def fake_run(spec, on_event=None):
+        captured["backend"] = spec.backend
+        return result
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.side_effect = fake_run
+        await srv.sandbox_run(task="t", repo="https://github.com/org/r", backend="claude")
+
+    assert captured["backend"] == "claude"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_on_event_pushes_to_store(fresh_store):
+    """on_event callback emitted by ModalSandbox.run reaches the store."""
+    def fake_run(spec, on_event=None):
+        if on_event:
+            on_event("phase", {"phase": "RUNNING"})
+        return _ok_result()
+
+    with patch("mcp_server.server.ModalSandbox") as MockSandbox:
+        MockSandbox.return_value.run.side_effect = fake_run
+        out = await srv.sandbox_run(task="t", repo="https://github.com/org/r")
+
+    run_id = out["run_id"]
+    events = fresh_store.events_from(run_id, 0)
+    phase_events = [e for e in events if e["type"] == "phase"]
+    assert any(e["phase"] == "RUNNING" for e in phase_events)
+
+
+# ------------------------------------------------------------------ sandbox_list
+
+
+@pytest.mark.asyncio
+async def test_sandbox_list_empty(fresh_store):
+    result = await srv.sandbox_list()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_sandbox_list_returns_runs(fresh_store):
+    fresh_store.create_run("r1", "https://github.com/o/a", "task A", "opencode")
+    fresh_store.create_run("r2", "https://github.com/o/b", "task B", "claude")
+
+    result = await srv.sandbox_list()
+    ids = {r["run_id"] for r in result}
+    assert ids == {"r1", "r2"}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_list_sorted_newest_first(fresh_store):
+    import time
+
+    fresh_store.create_run("r1", "https://github.com/o/a", "A", "opencode")
+    time.sleep(0.01)
+    fresh_store.create_run("r2", "https://github.com/o/b", "B", "opencode")
+
+    result = await srv.sandbox_list()
+    assert result[0]["run_id"] == "r2"
+
+
+# ------------------------------------------------------------------ sandbox_status
+
+
+@pytest.mark.asyncio
+async def test_sandbox_status_missing_run(fresh_store):
+    result = await srv.sandbox_status("ghost")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_sandbox_status_returns_state_and_events(fresh_store):
+    fresh_store.create_run("r1", "https://github.com/o/a", "task", "opencode")
+    fresh_store.push_event("r1", "phase", {"phase": "RUNNING"})
+    fresh_store.push_event("r1", "log", {"text": "agent output"})
+
+    result = await srv.sandbox_status("r1")
+
+    assert result["run_id"] == "r1"
+    assert result["phase"] == "RUNNING"
+    assert len(result["events"]) == 2
+    assert result["events"][0]["type"] == "phase"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_status_events_exclude_result_key(fresh_store):
+    """The embedded AgentTaskResult object must not leak into the status response."""
+    fresh_store.create_run("r1", "https://github.com/o/a", "t", "opencode")
+    fresh_store.push_event("r1", "done", {"success": True, "result": _ok_result()})
+
+    result = await srv.sandbox_status("r1")
+    for event in result["events"]:
+        assert "result" not in event
+
+
+# ------------------------------------------------------------------ sandbox_stop
+
+
+@pytest.mark.asyncio
+async def test_sandbox_stop_missing_run(fresh_store):
+    result = await srv.sandbox_stop("ghost")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_sandbox_stop_marks_run_terminal(fresh_store):
+    fresh_store.create_run("r1", "https://github.com/o/a", "task", "opencode")
+
+    result = await srv.sandbox_stop("r1")
+
+    assert result["cancelled"] is True
+    assert fresh_store.is_terminal("r1") is True
+
+
+@pytest.mark.asyncio
+async def test_sandbox_stop_cancels_future(fresh_store):
+    fresh_store.create_run("r1", "https://github.com/o/a", "task", "opencode")
+    mock_future = MagicMock()
+    srv._futures["r1"] = mock_future
+
+    await srv.sandbox_stop("r1")
+
+    mock_future.cancel.assert_called_once()


### PR DESCRIPTION
## Summary

- **`mcp_server/server.py`** — FastMCP server exposing 4 tools over stdio (default) or SSE
- **`mcp_server/__main__.py`** — `python -m mcp_server.server` entry-point
- **`.claude/settings.json`** — checked-in MCP config; team gets it automatically after `git pull`
- **`.gemini/settings.json`** — same for Gemini CLI users
- **`Makefile`** — `make mcp`, `make dashboard`, `make test`, `make lint` convenience targets
- Renamed `mcp/` → `mcp_server/` to avoid shadowing the `mcp` SDK package at import time
- **`tests/unit/test_mcp_server.py`** — 15 unit tests (202 total, all passing)

Closes #23

## Tools registered

| Tool | Description |
|------|-------------|
| `sandbox_run` | Boot sandbox, run agent, return result dict (diff omitted — too large) |
| `sandbox_list` | List all runs sorted newest-first |
| `sandbox_status` | Full state + event log for a run_id |
| `sandbox_stop` | Cancel + mark terminal |

## Developer experience after merge

```jsonc
// .claude/settings.json is already committed — just fill in your tokens
```

Then in a Claude Code session:
```
"Use the sandbox to fix the rate limiting bug in org/myapp"
→ calls sandbox_run → PR #42 opened, 24 tests passed
```

## Test plan

- [x] 202 unit tests pass
- [ ] `make mcp` starts server cleanly (no import errors)
- [ ] `claude mcp list` shows `agent-container` after config applied
- [ ] `sandbox_run` tool call visible in Claude Code tool-use log
- [ ] `sandbox_stop` closes SSE stream in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)