### PR TITLE
feat(hardening): examples, Makefile targets, docs cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
-.PHONY: test lint mcp dashboard
+.PHONY: test test-integration test-e2e lint mcp dashboard
 
+# ── unit tests (no external services, always free) ──────────────────────────
 test:
 	python3 -m pytest tests/unit/ -v
 
+# ── integration tests (requires MODAL_TOKEN_ID + MODAL_TOKEN_SECRET) ────────
+test-integration:
+	python3 -m pytest tests/integration/ -v --tb=short -m integration
+
+# ── e2e tests (nightly — requires Modal tokens + live model endpoint) ────────
+test-e2e:
+	python3 -m pytest tests/integration/ tests/e2e/ -v --tb=short -m e2e
+
+# ── linting ──────────────────────────────────────────────────────────────────
 lint:
 	python3 -m ruff check .
 
+# ── servers ──────────────────────────────────────────────────────────────────
 mcp:
 	python3 -m mcp_server.server --transport stdio
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ agent-run \
 
 That's it. No Docker, no servers, no infrastructure setup.
 
+### Common commands
+
+```bash
+make test               # run unit tests
+make dashboard          # start live dashboard at http://localhost:8000
+make mcp                # start MCP server (stdio) for Claude Code / Gemini CLI
+make lint               # ruff check
+```
+
 ---
 
 ## Model setup
@@ -144,8 +153,8 @@ agent-run --backend gemini  ...    # Gemini CLI — Google AI / Vertex AI
 ## Dashboard
 
 ```bash
-agent-run dashboard
-# → http://localhost:8080
+make dashboard
+# → http://localhost:8000
 ```
 
 Live view of all running, completed, and failed agent runs. Each run streams phase changes and log
@@ -187,12 +196,19 @@ print(result.diff_stat)   # +67 −3
 The sandbox exposes an MCP server so you can trigger runs directly from your editor session.
 
 ```json
-// .claude/settings.json
+// .claude/settings.json  (already checked in — fill in your tokens)
 {
   "mcpServers": {
     "agent-container": {
-      "command": "python",
-      "args": ["-m", "mcp.server"]
+      "command": "python3",
+      "args": ["-m", "mcp_server.server"],
+      "env": {
+        "MODAL_TOKEN_ID": "",
+        "MODAL_TOKEN_SECRET": "",
+        "GITHUB_TOKEN": "",
+        "OPENAI_BASE_URL": "",
+        "OPENAI_API_KEY": ""
+      }
     }
   }
 }
@@ -225,26 +241,33 @@ test results, original task prompt). Human approval required before merge.
 
 ---
 
-## Testing strategy
+## Testing
+
+```bash
+make test               # unit tests — no external services, always free
+make test-integration   # Modal sandbox lifecycle with stub agent (no LLM)
+make test-e2e           # nightly — real model against fixture repo
+```
 
 | Layer | What runs | Cost | Trigger |
 |---|---|---|---|
-| Unit | Config, spec, result, sandbox (mocked) | $0 | Every commit |
-| Integration | Full Modal sandbox lifecycle, stub agent | Modal compute only | Every PR |
-| E2e | Real model + fixture repo | ~$0.05/run | Nightly |
+| Unit | All modules fully mocked | $0 | Every commit |
+| Integration | Real Modal sandbox, stub agent | Modal compute only | Every PR |
+| E2E | Real Modal sandbox + real model | ~$0.05/run | Nightly |
 
 ---
 
 ## Milestones
 
-| Milestone | Scope |
-|---|---|
-| M1: Core dataclasses | `SandboxConfig`, `AgentTaskSpec`, `AgentTaskResult` ✅ |
-| M2: Modal sandbox | `ModalSandbox` boot/run/teardown, CLI |
-| M3: Agent internals | OpenCode runner, test detection, git ops |
-| M4: Dashboard | FastAPI SSE API, live UI |
-| M5: Model serving | `modal/serve.py` — deploy open model on Modal GPU |
-| M6: MCP + backends | MCP server, Claude Code + Gemini CLI backends |
+| Milestone | Scope | Status |
+|---|---|---|
+| M1: Core dataclasses | `SandboxConfig`, `AgentTaskSpec`, `AgentTaskResult` | ✅ |
+| M2: Modal sandbox | `ModalSandbox` boot/run/teardown, CLI | ✅ |
+| M3: Agent internals | Backends, runner, tester, git ops, GitHub/GitLab providers | ✅ |
+| M4: Dashboard | FastAPI SSE API, live terminal UI | ✅ |
+| M5: Model serving | `modal/serve.py` — SGLang + Qwen3-Coder on Modal GPU | ✅ |
+| M6: MCP + backends | MCP server, Claude Code + Gemini CLI backends | ✅ |
+| M7: Hardening | CI workflows, examples, docs | ✅ |
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -5,8 +5,9 @@ The dashboard is a live admin view of all agent runs — running, completed, and
 ## Start
 
 ```bash
-agent-run dashboard
-# → http://localhost:8080
+make dashboard
+# or: uvicorn dashboard.app:app --reload --port 8000
+# → http://localhost:8000
 ```
 
 ## What you see

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,35 +5,68 @@ directly from Claude Code or Gemini CLI sessions — without leaving your editor
 
 ## Setup
 
+Both `.claude/settings.json` and `.gemini/settings.json` are already checked into this repo.
+Clone the repo, fill in your tokens, and the tools appear automatically.
+
 === "Claude Code"
 
-    Add to `.claude/settings.json` in your repo (checked in — team gets this automatically):
+    `.claude/settings.json` (already in the repo):
 
     ```json
     {
       "mcpServers": {
         "agent-container": {
-          "command": "python",
-          "args": ["-m", "mcp.server"]
+          "command": "python3",
+          "args": ["-m", "mcp_server.server"],
+          "env": {
+            "MODAL_TOKEN_ID": "",
+            "MODAL_TOKEN_SECRET": "",
+            "GITHUB_TOKEN": "",
+            "OPENAI_BASE_URL": "",
+            "OPENAI_API_KEY": ""
+          }
         }
       }
     }
+    ```
+
+    Verify with:
+    ```bash
+    claude mcp list
+    # agent-container   python3 -m mcp_server.server
     ```
 
 === "Gemini CLI"
 
-    Add to `~/.gemini/settings.json`:
+    `.gemini/settings.json` (already in the repo):
 
     ```json
     {
       "mcpServers": {
         "agent-container": {
-          "command": "python",
-          "args": ["-m", "mcp.server"]
+          "command": "python3",
+          "args": ["-m", "mcp_server.server"],
+          "env": {
+            "MODAL_TOKEN_ID": "",
+            "MODAL_TOKEN_SECRET": "",
+            "GITHUB_TOKEN": "",
+            "OPENAI_BASE_URL": "",
+            "OPENAI_API_KEY": ""
+          }
         }
       }
     }
     ```
+
+## Start the server standalone
+
+```bash
+make mcp
+# or: python3 -m mcp_server.server
+
+# SSE mode (remote / multi-client)
+python3 -m mcp_server.server --transport sse --port 8001
+```
 
 ## Usage
 
@@ -45,7 +78,7 @@ You:     "Fix the pagination bug in org/myapp"
 Claude:  I'll run that in the agent sandbox.
          [calls sandbox_run]
 
-         Done. PR #42 opened on branch agent/fix-pagination-20260410.
+         Done. PR #42 opened on branch agent/opencode-20260424-120000.
          +12 −3 in api/pagination.py. Tests: 24 passed.
 
          Want me to review the diff before it merges?
@@ -55,10 +88,10 @@ Claude:  I'll run that in the agent sandbox.
 
 | Tool | Description |
 |---|---|
-| `sandbox_run` | Start an agent task. Returns run ID immediately. |
-| `sandbox_status` | Get the current status of a run. |
-| `sandbox_list` | List all recent runs with status and PR links. |
-| `sandbox_stop` | Stop a running task and destroy its sandbox. |
+| `sandbox_run` | Boot a sandbox, run the agent, return the result. |
+| `sandbox_status` | Get the current phase + event log for a run. |
+| `sandbox_list` | List all runs (active, completed, failed) sorted newest-first. |
+| `sandbox_stop` | Cancel a running task and mark it terminal. |
 
 ### `sandbox_run` parameters
 
@@ -67,8 +100,9 @@ Claude:  I'll run that in the agent sandbox.
   "repo": "https://github.com/org/myapp",
   "task": "Fix the off-by-one in paginate()",
   "backend": "opencode",
-  "branch": "main",
+  "base_branch": "main",
   "create_pr": true,
+  "run_tests": true,
   "timeout_seconds": 300
 }
 ```
@@ -78,9 +112,9 @@ Claude:  I'll run that in the agent sandbox.
 Both CLIs can trigger runs via their Bash tool without any MCP setup:
 
 ```bash
-# inside a Claude Code session
-$ agent-run --repo https://github.com/org/myapp --task "Fix the login bug"
+# inside a Claude Code or Gemini CLI session
+agent-run --repo https://github.com/org/myapp --task "Fix the login bug"
 ```
 
-MCP is the upgrade: structured typed output, progress streaming, and no raw terminal dump in
+MCP is the upgrade: structured typed output, progress notifications, and no raw terminal dump in
 the conversation.

--- a/examples/fix_bug.py
+++ b/examples/fix_bug.py
@@ -1,0 +1,41 @@
+"""Example 1 — minimal Python API usage.
+
+Runs an agent task against a public fixture repo, prints the result.
+
+Usage:
+    MODAL_TOKEN_ID=... MODAL_TOKEN_SECRET=... GITHUB_TOKEN=... \\
+    OPENAI_BASE_URL=... OPENAI_API_KEY=... \\
+    python3 examples/fix_bug.py
+"""
+
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox
+from sandbox.spec import AgentTaskSpec
+
+config = SandboxConfig.from_env()
+
+spec = AgentTaskSpec(
+    repo="https://github.com/dvdthecoder/agent-container-fixture",
+    task=(
+        "The function sum_to_n() in mathlib.py has an off-by-one bug: "
+        "it uses range(1, n) but should use range(1, n + 1). "
+        "Fix the bug so that all tests in test_mathlib.py pass."
+    ),
+    backend="opencode",
+    base_branch="main",
+    create_pr=True,
+    run_tests=True,
+    timeout_seconds=300,
+)
+
+print("Booting sandbox…")
+result = ModalSandbox(config).run(spec)
+
+if result.success:
+    print(f"Done in {result.duration_seconds:.1f}s")
+    print(f"Diff stat : {result.diff_stat}")
+    print(f"PR        : {result.pr_url or '(no PR — no diff or token missing)'}")
+    if result.tests:
+        print(f"Tests     : {result.tests.passed} passed, {result.tests.failed} failed")
+else:
+    print(f"Failed: {result.error}")

--- a/examples/mcp_client.py
+++ b/examples/mcp_client.py
@@ -1,0 +1,69 @@
+"""Example 3 — programmatic MCP client using fastmcp.
+
+Shows how to call the agent-container MCP tools from Python code — useful for
+testing the server locally or building higher-level automation on top of it.
+
+The MCP server must be running before this script is executed:
+    make mcp   (or: python3 -m mcp_server.server --transport sse --port 8001)
+
+Usage (SSE transport):
+    python3 examples/mcp_client.py
+
+To test with stdio transport directly from code, import the FastMCP app
+object and call the tools as regular async functions instead:
+
+    from mcp_server.server import sandbox_run, sandbox_list
+    import asyncio
+    result = asyncio.run(sandbox_run(task="...", repo="..."))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+
+async def demo_via_direct_import() -> None:
+    """Call the MCP tool functions directly — no transport layer needed.
+
+    This is the fastest way to test logic without a running server.
+    """
+    # Import the tool functions directly — they are plain async functions.
+    from mcp_server.server import sandbox_list, sandbox_run, sandbox_status, sandbox_stop
+
+    print("=== sandbox_list (empty) ===")
+    runs = await sandbox_list()
+    print(json.dumps(runs, indent=2))
+
+    print("\n=== sandbox_run (stub backend — no LLM cost) ===")
+    result = await sandbox_run(
+        task="Fix the off-by-one bug in sum_to_n() — use range(1, n + 1).",
+        repo="https://github.com/dvdthecoder/agent-container-fixture",
+        backend="stub",
+        create_pr=False,
+        run_tests=False,
+        timeout_seconds=120,
+    )
+    print(json.dumps(result, indent=2, default=str))
+
+    run_id = result["run_id"]
+
+    print(f"\n=== sandbox_status({run_id}) ===")
+    status = await sandbox_status(run_id)
+    # Show phase + first 3 events only to keep output short.
+    print(f"phase  : {status['phase']}")
+    print(f"events : {len(status['events'])} total")
+    for ev in status["events"][:3]:
+        print(f"  {ev['type']:8}  {ev.get('phase') or ev.get('text', '')[:60]}")
+
+    print(f"\n=== sandbox_list (after run) ===")
+    runs = await sandbox_list()
+    print(f"{len(runs)} run(s) recorded")
+
+    print(f"\n=== sandbox_stop({run_id}) — already terminal, noop ===")
+    stop = await sandbox_stop(run_id)
+    print(json.dumps(stop, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(demo_via_direct_import())

--- a/examples/run_with_dashboard.py
+++ b/examples/run_with_dashboard.py
@@ -1,0 +1,76 @@
+"""Example 2 — run an agent task and watch progress via the WorkspaceStore.
+
+Fires a run in a background thread (the same way the dashboard does) and
+prints each lifecycle event as it arrives.  No HTTP server needed — the store
+is shared in-process.
+
+Usage:
+    MODAL_TOKEN_ID=... MODAL_TOKEN_SECRET=... \\
+    OPENAI_BASE_URL=... OPENAI_API_KEY=... \\
+    python3 examples/run_with_dashboard.py
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+from dashboard.store import WorkspaceStore
+from sandbox.config import SandboxConfig
+from sandbox.sandbox import ModalSandbox
+from sandbox.spec import AgentTaskSpec
+
+store = WorkspaceStore()
+run_id = uuid.uuid4().hex[:12]
+
+REPO = "https://github.com/dvdthecoder/agent-container-fixture"
+TASK = "Fix the off-by-one bug in sum_to_n() in mathlib.py."
+
+store.create_run(run_id=run_id, repo=REPO, task=TASK, backend="stub")
+
+
+def on_event(event_type: str, payload: dict) -> None:
+    store.push_event(run_id, event_type, payload)
+
+
+def _run() -> None:
+    spec = AgentTaskSpec(
+        repo=REPO,
+        task=TASK,
+        backend="stub",     # stub agent — no LLM tokens spent
+        create_pr=False,
+        run_tests=False,
+        timeout_seconds=120,
+    )
+    ModalSandbox(SandboxConfig.from_env()).run(spec, on_event=on_event)
+
+
+executor = ThreadPoolExecutor(max_workers=1)
+future = executor.submit(_run)
+
+print(f"Run {run_id} started — polling for events…\n")
+cursor = 0
+
+while True:
+    events = store.events_from(run_id, cursor)
+    for ev in events:
+        ts = time.strftime("%H:%M:%S", time.localtime(ev["ts"]))
+        if ev["type"] == "phase":
+            print(f"[{ts}] PHASE → {ev['phase']}")
+        elif ev["type"] == "log" and ev.get("text", "").strip():
+            for line in ev["text"].strip().splitlines():
+                print(f"[{ts}]   {line}")
+        elif ev["type"] == "done":
+            ok = ev.get("success")
+            msg = "SUCCESS" if ok else f"FAILED — {ev.get('error', '')}"
+            print(f"[{ts}] DONE  → {msg}")
+    cursor += len(events)
+
+    if store.is_terminal(run_id):
+        break
+
+    time.sleep(0.5)
+
+future.result()
+print("\nFinal state:", store.get_run(run_id).phase)


### PR DESCRIPTION
## Summary

- **`examples/fix_bug.py`** — minimal Python API: `SandboxConfig → AgentTaskSpec → ModalSandbox.run()`
- **`examples/run_with_dashboard.py`** — in-process event polling via `WorkspaceStore` (same pattern the dashboard uses)
- **`examples/mcp_client.py`** — direct async calls to MCP tool functions without needing a running server
- **`Makefile`** — added `make test-integration` and `make test-e2e` targets
- **`docs/mcp.md`** — fixed stale `mcp.server` → `mcp_server.server`, added `make mcp`, full settings.json with env vars
- **`docs/dashboard.md`** — fixed startup command to `make dashboard` / port 8000
- **`README.md`** — fixed MCP module path, added `make` quickstart block, updated milestones table (all M1–M7 ✅)

Closes #15, #17, #18

## Test plan

- [x] 202 unit tests pass (`make test`)
- [ ] `python3 examples/fix_bug.py` runs against fixture repo (requires Modal + model tokens)
- [ ] `python3 examples/run_with_dashboard.py` streams events in terminal
- [ ] `python3 examples/mcp_client.py` calls tools directly and prints JSON output
- [ ] `make mcp` starts server with no import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)