### PR TITLE
fix(models): correct MiniMax API URL and verified model identifiers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ MODAL_TOKEN_SECRET=as-...
 # ── Model endpoint — pick ONE of the three options below ───────────────────────
 
 # Option 1: MiniMax M2.5 hosted API (recommended — no GPU setup, top SWE-bench score)
-# Get your key at platform.minimax.chat
-OPENAI_BASE_URL=https://api.minimax.chat/v1
+# Get your key at platform.minimax.io → Account Management → API Keys
+# Models: MiniMax-M2.7 (latest) | MiniMax-M2.7-highspeed | MiniMax-M2.5 | MiniMax-M2.5-highspeed
+OPENAI_BASE_URL=https://api.minimax.io/v1
 OPENAI_API_KEY=your-minimax-api-key
 OPENCODE_MODEL=MiniMax-M2.5
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Two options — both work with zero code changes:
 
 **Option A — MiniMax M2.5 hosted API** (recommended, no GPU setup):
 ```bash
-OPENAI_BASE_URL=https://api.minimax.chat/v1
-OPENAI_API_KEY=your-minimax-api-key   # platform.minimax.chat
+OPENAI_BASE_URL=https://api.minimax.io/v1
+OPENAI_API_KEY=your-minimax-api-key   # platform.minimax.io → Account Management → API Keys
 OPENCODE_MODEL=MiniMax-M2.5
 ```
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -23,15 +23,16 @@ standard benchmark for autonomous code editing on real repositories.
 | Active params | ~45B (out of 456B total) |
 | Context window | 1 000 000 tokens |
 | SWE-bench score | **#1 as of 2026-04** |
+| Latest model | MiniMax-M2.7 (M2.5 is previous, both available) |
 
 ### Route A — Hosted API (fastest setup, no GPU cost)
 
-Get an API key at **platform.minimax.chat**, then set three env vars:
+Get an API key at **platform.minimax.io** → Account Management → API Keys, then set:
 
 ```bash
-OPENAI_BASE_URL=https://api.minimax.chat/v1
+OPENAI_BASE_URL=https://api.minimax.io/v1
 OPENAI_API_KEY=your-minimax-api-key
-OPENCODE_MODEL=MiniMax-M2.5
+OPENCODE_MODEL=MiniMax-M2.5           # or MiniMax-M2.7 (latest), MiniMax-M2.5-highspeed
 ```
 
 Done. No deployment step — `agent-run` calls the MiniMax API directly from inside the

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -25,7 +25,7 @@ Add it to .env:
   OPENCODE_MODEL=<SERVED_MODEL_NAME from profile below>
 
 Alternatively, use MiniMax's hosted API instead (no GPU required):
-  OPENAI_BASE_URL=https://api.minimax.chat/v1
+  OPENAI_BASE_URL=https://api.minimax.io/v1
   OPENAI_API_KEY=<your-minimax-api-key>
   OPENCODE_MODEL=MiniMax-M2.5
 """


### PR DESCRIPTION
## What was wrong

The MiniMax base URL was `api.minimax.chat` — that domain returns 404. Verified against their actual docs.

## Verified facts (source: platform.minimax.io/docs/api-reference/text-chat-openai.md)

| Field | Value |
|---|---|
| Base URL | `https://api.minimax.io/v1` |
| Auth | `Authorization: Bearer YOUR_API_KEY` |
| M2.5 model ID | `MiniMax-M2.5` ✅ |
| M2.7 model ID | `MiniMax-M2.7` (latest, released after M2.5) |
| High-speed variants | `MiniMax-M2.5-highspeed`, `MiniMax-M2.7-highspeed` |
| API key source | platform.minimax.io → Account Management → API Keys |

## Changes

- `.env.example` — corrected URL, added model variant comments
- `docs/models.md` — corrected URL, platform link, added M2.7 note
- `README.md` — corrected URL and platform link
- `modal/serve.py` — corrected URL in docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)