### PR TITLE
chore(docs): refresh README and mkdocs to match current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ PR is opened, and the sandbox is destroyed. The agent never touches your local m
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  agent-run CLI  /  Dashboard (localhost:8080)            │
+│  agent-run CLI  /  Dashboard (localhost:8000)            │
 │  Python API     /  MCP server (Claude Code, Gemini CLI)  │
 └──────────────────────┬───────────────────────────────────┘
                        │
@@ -53,9 +53,9 @@ PR is opened, and the sandbox is destroyed. The agent never touches your local m
                        │  Modal internal network
                        ▼
 ┌──────────────────────────────────────────────────────────┐
-│  Modal GPU — SGLang inference server                     │
-│  modal deploy modal/serve.py                             │
-│  Qwen3-Coder on A100 · RadixAttention · scale-to-zero   │
+│  Model endpoint — pluggable                              │
+│  MiniMax M2.5 hosted API  (recommended)                  │
+│  or: modal deploy modal/serve.py  (SGLang, scale-to-0)  │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -87,10 +87,10 @@ MODAL_TOKEN_SECRET=...
 # Git provider
 GITHUB_TOKEN=ghp_...
 
-# Model endpoint — pick one (see Model Setup below)
-OPENAI_BASE_URL=https://api.together.xyz/v1
-OPENAI_API_KEY=your-together-key
-OPENCODE_MODEL=Qwen/Qwen3-Coder-80B-Instruct
+# Model endpoint — MiniMax M2.5 hosted API (recommended)
+OPENAI_BASE_URL=https://api.minimax.io/v1
+OPENAI_API_KEY=your-minimax-api-key
+OPENCODE_MODEL=MiniMax-M2.5
 ```
 
 ### 3. Run

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -35,8 +35,9 @@ OPENAI_API_KEY=...
 OPENCODE_MODEL=...
 ```
 
-**Best for**: teams using self-hosted or third-party models (Together.ai, Modal GPU, SGLang).
-OpenCode routes all calls through `OPENAI_BASE_URL`, so the model is fully under your control.
+**Best for**: teams wanting the highest quality results. Point `OPENAI_BASE_URL` at MiniMax's hosted
+API for the #1 SWE-bench model with zero GPU setup, or at a self-hosted SGLang endpoint for full
+air-gap deployments. The model is fully under your control.
 
 Invoked inside the container as:
 ```bash
@@ -95,8 +96,8 @@ backend keeps prompts within your GCP project.
 |---|---|---|---|
 | Model | Any via `OPENAI_BASE_URL` | Anthropic API | Google AI / Vertex |
 | Open source | ✅ | ❌ | ✅ |
-| Air-gap capable | ✅ (with SGLang) | ❌ | ✅ (Vertex AI) |
-| SWE-bench (best model) | 70.6 (Qwen3-Coder) | 72.5 (Claude Sonnet) | ~65 (Gemini 2.5 Pro) |
+| Air-gap capable | ✅ (with SGLang or MiniMax) | ❌ | ✅ (Vertex AI) |
+| Recommended model | MiniMax-M2.5 (#1 SWE-bench) | Claude Sonnet 4.5 | Gemini 2.5 Pro |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Your terminal / dashboard / Claude Code session
         ↓
   Coding agent   ← OpenCode / Claude Code CLI / Gemini CLI
         ↓
-  Model endpoint ← pluggable: Together.ai / Modal GPU / SGLang / Anthropic
+  Model endpoint ← pluggable: MiniMax API / Modal GPU / SGLang / Anthropic
         ↓
   GitHub / GitLab PR
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,8 @@ Get your first agent task running in under 5 minutes.
 - Python 3.11+
 - A [Modal](https://modal.com) account (free tier works)
 - A GitHub personal access token
-- A model endpoint (see options below — Together.ai is easiest)
+- A MiniMax API key — get one at [platform.minimax.io](https://platform.minimax.io) (recommended)
+  or any other OpenAI-compatible model endpoint
 
 ## 1. Install
 
@@ -20,38 +21,41 @@ pip install agent-container
 ```bash
 pip install modal
 modal token new
-# follow the browser prompt — sets MODAL_TOKEN_ID and MODAL_TOKEN_SECRET in ~/.modal.toml
+# follow the browser prompt — saves token to ~/.modal.toml
 ```
 
-## 3. Deploy the model
-
-```bash
-modal deploy modal/serve.py
-```
-
-This starts Qwen3-Coder on an A100 GPU inside Modal. The sandbox calls it automatically over
-Modal's internal network — nothing else to configure.
-
-## 4. Configure
+## 3. Configure
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env`:
+Edit `.env` — the minimum required fields:
 
 ```bash
-# Modal
+# Modal — sandbox compute
 MODAL_TOKEN_ID=ak-...
 MODAL_TOKEN_SECRET=as-...
 
 # GitHub
 GITHUB_TOKEN=ghp_...
+
+# Model — MiniMax M2.5 hosted API (recommended, no GPU setup)
+OPENAI_BASE_URL=https://api.minimax.io/v1
+OPENAI_API_KEY=your-minimax-api-key
+OPENCODE_MODEL=MiniMax-M2.5
 ```
 
-That's all that's required. The model endpoint is wired up inside Modal.
+!!! tip "Self-hosted model (optional)"
+    To run the model on your own Modal GPU instead:
+    ```bash
+    modal deploy modal/serve.py            # Qwen3-Coder 8B (test)
+    SERVE_PROFILE=prod modal deploy ...    # Qwen3-Coder 80B
+    SERVE_PROFILE=minimax modal deploy ... # MiniMax M2.5 on 8× A100
+    ```
+    Then set `OPENAI_BASE_URL` to the printed endpoint URL.
 
-## 6. Run your first task
+## 4. Run your first task
 
 ```bash
 agent-run \
@@ -65,24 +69,36 @@ Output:
 [sandbox] booting Modal container...
 [clone]   git clone https://github.com/org/myapp
 [agent]   running opencode...
-[pr]      opening PR on branch agent/fix-pagination-20260410-143022
+[pr]      opening PR on branch agent/opencode-20260424-143022
 ✓ Done in 1m 52s
 PR: https://github.com/org/myapp/pull/42   +12 −3
 ```
 
-## 7. Start the dashboard (optional)
+## 5. Start the dashboard (optional)
 
 ```bash
-agent-run dashboard
+make dashboard
+# → http://localhost:8000
 ```
 
-Open [http://localhost:8080](http://localhost:8080) to see live run status, logs, and history.
+Live view of all running, completed, and failed agent runs — phases, log stream, PR links.
+
+## 6. Wire up MCP (optional)
+
+`.claude/settings.json` and `.gemini/settings.json` are already checked into the repo.
+Fill in your tokens and the `sandbox_run`, `sandbox_list`, `sandbox_status`, `sandbox_stop`
+tools appear automatically in Claude Code and Gemini CLI.
+
+```bash
+make mcp      # start MCP server standalone (stdio)
+claude mcp list   # verify agent-container appears
+```
 
 ---
 
 ## Next steps
 
-- [Model Setup](models.md) — switch to a self-hosted or private model
+- [Model Setup](models.md) — MiniMax hosted vs self-hosted, all profiles
 - [Agent Backends](agents.md) — use Claude Code or Gemini CLI instead of OpenCode
 - [MCP Integration](mcp.md) — trigger runs from inside Claude Code
 - [Enterprise & GitLab](enterprise.md) — GitLab MRs, air-gap setup


### PR DESCRIPTION
## What was stale

| File | Issue | Fix |
|---|---|---|
| `README.md` | Architecture diagram said `localhost:8080` | → `8000` |
| `README.md` | Quickstart config showed Together.ai example | → MiniMax M2.5 hosted API |
| `README.md` | Model layer in diagram mentioned Qwen3-Coder only | → MiniMax M2.5 + pluggable |
| `docs/quickstart.md` | Step 3 told users to `modal deploy` Qwen3-Coder | → MiniMax hosted as default, self-host as tip |
| `docs/quickstart.md` | Dashboard step pointed to `localhost:8080` + `agent-run dashboard` | → `make dashboard` + port 8000 |
| `docs/quickstart.md` | Missing step 5, jump from 4 to 6 | → Added MCP wiring step |
| `docs/quickstart.md` | Prerequisites said "Together.ai is easiest" | → MiniMax hosted |
| `docs/agents.md` | SWE-bench table showed `70.6 (Qwen3-Coder)` as best | → `MiniMax-M2.5 (#1 SWE-bench)` |
| `docs/index.md` | Diagram showed `Together.ai` as model option | → `MiniMax API` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)