### PR TITLE
feat: per-phase timeouts (#64/#65) + proxy unit tests (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ spec = AgentTaskSpec(
     backend="aider",
     create_pr=True,
     run_tests=True,
+    # Per-phase timeouts — each phase gets its own budget:
+    timeout_coldstart=300,  # poll inference endpoint until ready
+    timeout_agent=600,      # agent execution (OPENCODE_TIMEOUT)
+    timeout_tests=120,      # test suite execution
+    # total Modal sandbox lifetime = sum of all three
 )
 
 result = ModalSandbox(config).run(spec)
@@ -298,6 +303,10 @@ make test               # unit tests — no external services, always free
 make test-integration   # real Modal sandbox, stub agent (no LLM needed)
 make test-e2e           # real Modal sandbox + real model
 ```
+
+263 unit tests covering config, spec, sandbox, git ops, runner, tester, proxy, dashboard, MCP, and CLI. All run in-process with no external services.
+
+The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the complete Responses API → Chat Completions translation including the full SSE event sequence required by opencode's agentic loop.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -249,13 +249,18 @@ make dashboard
 # → http://localhost:8000
 ```
 
-Live view of all runs — CLI and dashboard-started — newest first. Each run is a collapsible row:
-collapsed shows the phase indicator, repo, backend, and whether the run was started from the CLI
-or the dashboard; expanded shows the full log stream inline.
+Two-tab interface:
 
-The left sidebar has a **serve panel** (deploy the model server from the UI, choose profile and
-model) and the new-run form. Both CLI and dashboard runs write to the same SQLite log at
-`~/.agent-container/runs.db`.
+**Runs tab** — live view of all runs (CLI + dashboard), newest first. Each row is collapsible:
+collapsed shows the phase indicator, repo, backend, and source; expanded shows the full inline
+log stream.
+
+**Tokens tab** — per-run token consumption table. Sortable by any column. Filters: backend,
+date range. `$/1M tokens` rate input recalculates the cost estimate column live without reload.
+Summary bar shows cumulative tokens and estimated cost across visible runs.
+
+The left sidebar has a **serve panel** (deploy the model server from the UI) and the new-run
+form. Both CLI and dashboard runs write to the same SQLite log at `~/.agent-container/runs.db`.
 
 ---
 
@@ -304,9 +309,9 @@ make test-integration   # real Modal sandbox, stub agent (no LLM needed)
 make test-e2e           # real Modal sandbox + real model
 ```
 
-263 unit tests covering config, spec, sandbox, git ops, runner, tester, proxy, dashboard, MCP, and CLI. All run in-process with no external services.
+271 unit tests covering config, spec, sandbox, git ops, runner, tester, proxy, log store, dashboard, MCP, and CLI. All run in-process with no external services.
 
-The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the complete Responses API → Chat Completions translation including the full SSE event sequence required by opencode's agentic loop.
+The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the complete Responses API → Chat Completions translation including the full SSE event sequence and token accumulation logic.
 
 ---
 

--- a/agent/log_store.py
+++ b/agent/log_store.py
@@ -56,7 +56,10 @@ CREATE TABLE IF NOT EXISTS runs (
     branch          TEXT,
     pr_url          TEXT,
     duration_s      REAL,
-    sandbox_id      TEXT
+    sandbox_id      TEXT,
+    prompt_tokens   INTEGER,
+    completion_tokens INTEGER,
+    total_tokens    INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS events (
@@ -95,6 +98,9 @@ class RunRow:
     pr_url: str | None
     duration_s: float | None
     sandbox_id: str | None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
 
 
 @dataclass
@@ -143,6 +149,9 @@ class RunLogger:
             ("initiated_by", "TEXT NOT NULL DEFAULT 'cli'"),
             ("base_branch", "TEXT NOT NULL DEFAULT 'main'"),
             ("timeout_seconds", "INTEGER NOT NULL DEFAULT 600"),
+            ("prompt_tokens", "INTEGER"),
+            ("completion_tokens", "INTEGER"),
+            ("total_tokens", "INTEGER"),
         ]
         for col, defn in migrations:
             if col not in existing:
@@ -198,6 +207,21 @@ class RunLogger:
                 "INSERT INTO events (run_id, ts, elapsed_s, phase, source, level, message)"
                 " VALUES (?,?,?,?,?,?,?)",
                 (self.run_id, now, round(elapsed, 3), ph, source, level, message),
+            )
+            self._conn.commit()
+
+    def set_token_usage(
+        self,
+        prompt_tokens: int,
+        completion_tokens: int,
+        total_tokens: int,
+    ) -> None:
+        """Persist token consumption for this run (parsed from runner stderr)."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE runs SET prompt_tokens=?, completion_tokens=?, total_tokens=?"
+                " WHERE run_id=?",
+                (prompt_tokens, completion_tokens, total_tokens, self.run_id),
             )
             self._conn.commit()
 

--- a/agent/opencode_runner.py
+++ b/agent/opencode_runner.py
@@ -58,6 +58,22 @@ TOOL_CHOICE = os.environ.get("OPENCODE_TOOL_CHOICE", "required")
 
 _PROXY_PORT = 8080
 
+# ---------------------------------------------------------------------------
+# Token usage accumulator — aggregated across all proxy turns this session
+# ---------------------------------------------------------------------------
+
+_token_counts: dict[str, int] = {"prompt": 0, "completion": 0}
+_token_lock = threading.Lock()
+
+
+def _accumulate_tokens(usage: dict) -> None:
+    """Thread-safely add *usage* totals to the session-level accumulator."""
+    if not usage:
+        return
+    with _token_lock:
+        _token_counts["prompt"] += int(usage.get("prompt_tokens", 0) or 0)
+        _token_counts["completion"] += int(usage.get("completion_tokens", 0) or 0)
+
 
 # ---------------------------------------------------------------------------
 # Format conversion helpers
@@ -239,6 +255,9 @@ class _ProxyHandler(http.server.BaseHTTPRequestHandler):
                 chat_req[key] = req[key]
 
         stream = chat_req["stream"]
+        # Request per-response usage stats from vLLM so we can track token consumption.
+        if stream:
+            chat_req["stream_options"] = {"include_usage": True}
         chat_body = json.dumps(chat_req).encode()
         url = f"{self.target}/v1/chat/completions"
         print(
@@ -262,7 +281,13 @@ class _ProxyHandler(http.server.BaseHTTPRequestHandler):
                 if stream:
                     self._stream_chat_to_responses(resp)
                 else:
-                    translated = self._translate_chat_response(resp.read())
+                    raw = resp.read()
+                    # Accumulate token usage from the non-streaming response.
+                    try:
+                        _accumulate_tokens(json.loads(raw).get("usage", {}))
+                    except Exception:  # noqa: BLE001, S110
+                        pass
+                    translated = self._translate_chat_response(raw)
                     self._send(200, translated)
         except urllib.error.HTTPError as e:
             body_err = e.read()
@@ -360,6 +385,10 @@ class _ProxyHandler(http.server.BaseHTTPRequestHandler):
                 chunk = json.loads(data)
             except json.JSONDecodeError:
                 continue
+
+            # vLLM emits a final chunk with `usage` when stream_options.include_usage=true.
+            if chunk.get("usage"):
+                _accumulate_tokens(chunk["usage"])
 
             delta = chunk.get("choices", [{}])[0].get("delta", {})
             text_delta = delta.get("content") or ""
@@ -781,6 +810,17 @@ def main() -> int:
         return 1
 
     client.terminate()
+
+    # Emit token usage so the host process can persist it to the run log.
+    with _token_lock:
+        p = _token_counts["prompt"]
+        c = _token_counts["completion"]
+    print(
+        f"[runner] token_usage: prompt={p} completion={c} total={p + c}",
+        file=sys.stderr,
+        flush=True,
+    )
+
     return 0
 
 

--- a/dashboard/router.py
+++ b/dashboard/router.py
@@ -8,6 +8,7 @@ GET  /runs/{id}         — get a single run (SQLite metadata + live phase if ac
 DELETE /runs/{id}        — cancel a queued/running run (best-effort)
 GET  /runs/{id}/stream  — SSE stream of lifecycle events (dashboard runs only)
 GET  /runs/{id}/events  — past log events from SQLite (for replay on page load)
+GET  /tokens            — token usage per run, sorted by total_tokens desc
 GET  /serve/status      — model server status (deployed / idle / unknown)
 POST /serve/deploy      — trigger a modal deploy for the given profile
 """
@@ -219,6 +220,54 @@ async def stream_run(run_id: str) -> StreamingResponse:
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ------------------------------------------------------------------ /tokens route
+
+
+@router.get("/tokens")
+def list_tokens(backend: str = "", date_from: str = "", date_to: str = "") -> list[dict[str, Any]]:
+    """Return per-run token usage sorted by total_tokens descending.
+
+    Optional query params:
+      backend   — filter by backend name (e.g. "opencode")
+      date_from — ISO date string lower bound on started_at (inclusive)
+      date_to   — ISO date string upper bound on started_at (inclusive)
+    """
+    try:
+        rows = run_store.list_runs(limit=500)
+    except FileNotFoundError:
+        return []
+
+    result = []
+    for row in rows:
+        # Skip runs with no token data.
+        if row.total_tokens is None:
+            continue
+        if backend and row.backend != backend:
+            continue
+        if date_from and row.started_at < date_from:
+            continue
+        if date_to and row.started_at > date_to + "T23:59:59":
+            continue
+        result.append(
+            {
+                "run_id": row.run_id,
+                "repo": row.repo,
+                "task": row.task,
+                "backend": row.backend,
+                "started_at": row.started_at,
+                "outcome": row.outcome,
+                "prompt_tokens": row.prompt_tokens or 0,
+                "completion_tokens": row.completion_tokens or 0,
+                "total_tokens": row.total_tokens or 0,
+                "duration_s": row.duration_s,
+            }
+        )
+
+    # Sort by total_tokens descending — heaviest runs first.
+    result.sort(key=lambda r: r["total_tokens"], reverse=True)
+    return result
 
 
 # ------------------------------------------------------------------ /serve routes

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -424,6 +424,113 @@
       margin-left: auto;
     }
     .pr-link:hover { opacity: .85; }
+
+    /* ---- tab bar ---- */
+    #tab-bar {
+      display: flex;
+      gap: 0;
+      border-bottom: 2px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+      padding: 0 12px;
+    }
+    .tab-btn {
+      background: none;
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 600;
+      padding: 10px 14px;
+      cursor: pointer;
+      transition: color .1s;
+    }
+    .tab-btn:hover { color: var(--text); }
+    .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+    /* ---- tab panels ---- */
+    .tab-panel { display: none; flex-direction: column; flex: 1; overflow: hidden; }
+    .tab-panel.active { display: flex; }
+
+    /* ---- tokens tab ---- */
+    #tokens-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+      flex-wrap: wrap;
+    }
+    #tokens-toolbar label { font-size: 11px; color: var(--muted); margin: 0; white-space: nowrap; }
+    #tokens-toolbar select, #tokens-toolbar input {
+      width: auto; font-size: 12px; padding: 4px 6px; background: var(--bg);
+    }
+    #tokens-toolbar input[type="number"] { width: 80px; }
+    #tokens-toolbar input[type="date"]   { width: 130px; }
+    #tokens-summary {
+      margin-left: auto;
+      font-size: 11px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    /* tokens table */
+    #tokens-scroll { overflow-y: auto; flex: 1; }
+    #tokens-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    #tokens-table th {
+      position: sticky;
+      top: 0;
+      background: var(--surface);
+      z-index: 4;
+      padding: 6px 12px;
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      text-align: right;
+      border-bottom: 2px solid var(--border);
+      white-space: nowrap;
+      cursor: pointer;
+      user-select: none;
+    }
+    #tokens-table th:first-child,
+    #tokens-table th:nth-child(2),
+    #tokens-table th:nth-child(3),
+    #tokens-table th:nth-child(4) { text-align: left; }
+    #tokens-table th:hover { color: var(--accent); }
+    #tokens-table th.sort-asc::after  { content: " ↑"; }
+    #tokens-table th.sort-desc::after { content: " ↓"; }
+    #tokens-table td {
+      padding: 7px 12px;
+      border-bottom: 1px solid var(--border);
+      text-align: right;
+      vertical-align: middle;
+    }
+    #tokens-table td:first-child,
+    #tokens-table td:nth-child(2),
+    #tokens-table td:nth-child(3),
+    #tokens-table td:nth-child(4) { text-align: left; }
+    #tokens-table tr:hover td { background: rgba(88,166,255,.04); }
+    .tok-runid  { font-family: var(--mono); font-size: 11px; color: var(--muted); white-space: nowrap; }
+    .tok-repo   { color: var(--text); max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tok-backend { white-space: nowrap; }
+    .tok-outcome.success { color: var(--green); }
+    .tok-outcome.error, .tok-outcome.failed { color: var(--red); }
+    .tok-num    { font-family: var(--mono); color: var(--text); }
+    .tok-cost   { font-family: var(--mono); color: var(--yellow); }
+    #tokens-empty {
+      padding: 48px 32px;
+      color: var(--muted);
+      font-size: 13px;
+    }
   </style>
 </head>
 <body>
@@ -495,58 +602,117 @@
 
   </div>
 
-  <!-- ---- main run list ---- -->
+  <!-- ---- main area ---- -->
   <div id="main">
 
-    <!-- filter toolbar -->
-    <div id="filter-bar">
-      <label for="flt-status">Status</label>
-      <select id="flt-status" onchange="applyFilters()">
-        <option value="">All</option>
-        <option value="DONE">Done</option>
-        <option value="FAILED">Failed</option>
-        <option value="RUNNING">Running</option>
-        <option value="UNKNOWN">Unknown</option>
-      </select>
-
-      <label for="flt-backend">Backend</label>
-      <select id="flt-backend" onchange="applyFilters()">
-        <option value="">All</option>
-        <option value="aider">aider</option>
-        <option value="opencode">opencode</option>
-        <option value="claude">claude</option>
-        <option value="gemini">gemini</option>
-        <option value="stub">stub</option>
-      </select>
-
-      <label for="flt-source">Source</label>
-      <select id="flt-source" onchange="applyFilters()">
-        <option value="">All</option>
-        <option value="cli">cli</option>
-        <option value="dashboard">dashboard</option>
-      </select>
-
-      <span id="run-count"></span>
+    <!-- tab bar -->
+    <div id="tab-bar">
+      <button class="tab-btn active" onclick="switchTab('runs')">Runs</button>
+      <button class="tab-btn" onclick="switchTab('tokens')">Tokens</button>
     </div>
 
-    <!-- column headers -->
-    <div id="list-header">
-      <div class="col-hdr"></div>
-      <div class="col-hdr"></div>
-      <div class="col-hdr">Run ID</div>
-      <div class="col-hdr">Repository</div>
-      <div class="col-hdr">Started</div>
-      <div class="col-hdr">Ended</div>
-      <div class="col-hdr">Backend</div>
-      <div class="col-hdr">Source</div>
-      <div class="col-hdr">Status</div>
-      <div class="col-hdr">PR</div>
-    </div>
+    <!-- ===== RUNS TAB ===== -->
+    <div id="tab-runs" class="tab-panel active">
 
-    <div id="run-list">
-      <div id="empty-state">No runs yet — start one from the sidebar.</div>
-    </div>
-  </div>
+      <!-- filter toolbar -->
+      <div id="filter-bar">
+        <label for="flt-status">Status</label>
+        <select id="flt-status" onchange="applyFilters()">
+          <option value="">All</option>
+          <option value="DONE">Done</option>
+          <option value="FAILED">Failed</option>
+          <option value="RUNNING">Running</option>
+          <option value="UNKNOWN">Unknown</option>
+        </select>
+
+        <label for="flt-backend">Backend</label>
+        <select id="flt-backend" onchange="applyFilters()">
+          <option value="">All</option>
+          <option value="aider">aider</option>
+          <option value="opencode">opencode</option>
+          <option value="claude">claude</option>
+          <option value="gemini">gemini</option>
+          <option value="stub">stub</option>
+        </select>
+
+        <label for="flt-source">Source</label>
+        <select id="flt-source" onchange="applyFilters()">
+          <option value="">All</option>
+          <option value="cli">cli</option>
+          <option value="dashboard">dashboard</option>
+        </select>
+
+        <span id="run-count"></span>
+      </div>
+
+      <!-- column headers -->
+      <div id="list-header">
+        <div class="col-hdr"></div>
+        <div class="col-hdr"></div>
+        <div class="col-hdr">Run ID</div>
+        <div class="col-hdr">Repository</div>
+        <div class="col-hdr">Started</div>
+        <div class="col-hdr">Ended</div>
+        <div class="col-hdr">Backend</div>
+        <div class="col-hdr">Source</div>
+        <div class="col-hdr">Status</div>
+        <div class="col-hdr">PR</div>
+      </div>
+
+      <div id="run-list" style="overflow-y:auto;flex:1;">
+        <div id="empty-state">No runs yet — start one from the sidebar.</div>
+      </div>
+
+    </div><!-- /tab-runs -->
+
+    <!-- ===== TOKENS TAB ===== -->
+    <div id="tab-tokens" class="tab-panel">
+
+      <div id="tokens-toolbar">
+        <label for="tok-backend">Backend</label>
+        <select id="tok-backend" onchange="loadTokens()">
+          <option value="">All</option>
+          <option value="aider">aider</option>
+          <option value="opencode">opencode</option>
+          <option value="claude">claude</option>
+          <option value="gemini">gemini</option>
+        </select>
+
+        <label for="tok-from">From</label>
+        <input id="tok-from" type="date" onchange="loadTokens()" />
+
+        <label for="tok-to">To</label>
+        <input id="tok-to" type="date" onchange="loadTokens()" />
+
+        <label for="tok-rate" title="Cost per 1M tokens (USD). Used only for the estimate column.">$/1M tokens</label>
+        <input id="tok-rate" type="number" value="1.00" min="0" step="0.01" onchange="rerenderTokenCosts()" />
+
+        <span id="tokens-summary"></span>
+      </div>
+
+      <div id="tokens-scroll">
+        <div id="tokens-empty" style="display:none">No runs with token data yet. Token data is recorded for opencode runs once they complete.</div>
+        <table id="tokens-table" style="display:none">
+          <thead>
+            <tr>
+              <th onclick="sortTokens('run_id')">Run ID</th>
+              <th onclick="sortTokens('repo')">Repository</th>
+              <th onclick="sortTokens('backend')">Backend</th>
+              <th onclick="sortTokens('outcome')">Outcome</th>
+              <th onclick="sortTokens('prompt_tokens')">Prompt</th>
+              <th onclick="sortTokens('completion_tokens')">Completion</th>
+              <th onclick="sortTokens('total_tokens')">Total</th>
+              <th onclick="sortTokens('cost')">Est. cost</th>
+              <th onclick="sortTokens('duration_s')">Duration</th>
+            </tr>
+          </thead>
+          <tbody id="tokens-tbody"></tbody>
+        </table>
+      </div>
+
+    </div><!-- /tab-tokens -->
+
+  </div><!-- /main -->
 </div>
 
 <script>
@@ -911,6 +1077,131 @@ function renderRunSummary(run_id, detail) {
   if (detail.sandbox_id) row('sandbox',   detail.sandbox_id);
   if (detail.error)      row('error',     detail.error, 'fail');
   if (detail.diff_stat)  row('diff',      detail.diff_stat);
+}
+
+// ------------------------------------------------------------------ tabs
+function switchTab(name) {
+  document.querySelectorAll('.tab-btn').forEach((b, i) => {
+    const tabName = ['runs', 'tokens'][i];
+    b.classList.toggle('active', tabName === name);
+  });
+  document.querySelectorAll('.tab-panel').forEach(p => {
+    p.classList.toggle('active', p.id === `tab-${name}`);
+  });
+  if (name === 'tokens') loadTokens();
+}
+
+// ------------------------------------------------------------------ tokens tab
+let _tokensData = [];          // current loaded rows (after backend/date filter)
+let _tokensSortCol  = 'total_tokens';
+let _tokensSortDir  = -1;      // -1 = desc, 1 = asc
+
+async function loadTokens() {
+  const backend  = document.getElementById('tok-backend').value;
+  const dateFrom = document.getElementById('tok-from').value;
+  const dateTo   = document.getElementById('tok-to').value;
+
+  const params = new URLSearchParams();
+  if (backend)  params.set('backend',   backend);
+  if (dateFrom) params.set('date_from', dateFrom);
+  if (dateTo)   params.set('date_to',   dateTo);
+
+  try {
+    _tokensData = await fetch('/api/tokens?' + params).then(r => r.json());
+  } catch {
+    _tokensData = [];
+  }
+
+  renderTokensTable();
+}
+
+function sortTokens(col) {
+  if (_tokensSortCol === col) {
+    _tokensSortDir *= -1;
+  } else {
+    _tokensSortCol = col;
+    _tokensSortDir = col === 'run_id' || col === 'repo' || col === 'backend' || col === 'outcome' ? 1 : -1;
+  }
+  renderTokensTable();
+}
+
+function renderTokensTable() {
+  const rate = parseFloat(document.getElementById('tok-rate').value) || 0;
+  const table = document.getElementById('tokens-table');
+  const empty = document.getElementById('tokens-empty');
+  const summary = document.getElementById('tokens-summary');
+
+  if (!_tokensData.length) {
+    table.style.display = 'none';
+    empty.style.display = 'block';
+    summary.textContent = '';
+    return;
+  }
+
+  table.style.display = 'table';
+  empty.style.display = 'none';
+
+  // Update sort indicators on headers
+  table.querySelectorAll('th').forEach(th => {
+    th.classList.remove('sort-asc', 'sort-desc');
+  });
+  const colMap = ['run_id','repo','backend','outcome','prompt_tokens','completion_tokens','total_tokens','cost','duration_s'];
+  const thIdx = colMap.indexOf(_tokensSortCol);
+  if (thIdx >= 0) {
+    const th = table.querySelectorAll('th')[thIdx];
+    if (th) th.classList.add(_tokensSortDir === 1 ? 'sort-asc' : 'sort-desc');
+  }
+
+  // Sort
+  const sorted = [..._tokensData].sort((a, b) => {
+    let av = _tokensSortCol === 'cost'
+      ? (a.total_tokens / 1e6 * rate)
+      : (a[_tokensSortCol] ?? '');
+    let bv = _tokensSortCol === 'cost'
+      ? (b.total_tokens / 1e6 * rate)
+      : (b[_tokensSortCol] ?? '');
+    if (typeof av === 'string') return _tokensSortDir * av.localeCompare(bv);
+    return _tokensSortDir * ((av < bv ? -1 : av > bv ? 1 : 0));
+  });
+
+  // Totals for summary row
+  const totalPrompt     = _tokensData.reduce((s, r) => s + r.prompt_tokens, 0);
+  const totalCompletion = _tokensData.reduce((s, r) => s + r.completion_tokens, 0);
+  const totalAll        = _tokensData.reduce((s, r) => s + r.total_tokens, 0);
+  const totalCost       = totalAll / 1e6 * rate;
+  summary.textContent = `${_tokensData.length} run${_tokensData.length !== 1 ? 's' : ''} · ${fmtNum(totalAll)} total tokens · est. $${totalCost.toFixed(4)}`;
+
+  const tbody = document.getElementById('tokens-tbody');
+  tbody.innerHTML = '';
+  for (const row of sorted) {
+    const cost = row.total_tokens / 1e6 * rate;
+    const repoShort = row.repo.replace(/^https?:\/\/(www\.)?github\.com\//, '').replace(/\.git$/, '');
+    const dur = row.duration_s != null ? row.duration_s.toFixed(0) + 's' : '—';
+    const outcome = row.outcome || '—';
+    const outCls = outcome === 'success' ? 'success' : (outcome === 'error' || outcome === 'failed' ? 'failed' : '');
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="tok-runid">${escHtml(row.run_id)}</td>
+      <td><span class="tok-repo" title="${escHtml(row.repo)}">${escHtml(repoShort)}</span></td>
+      <td class="tok-backend"><span class="badge badge-backend">${escHtml(row.backend)}</span></td>
+      <td class="tok-outcome ${outCls}">${escHtml(outcome)}</td>
+      <td class="tok-num">${fmtNum(row.prompt_tokens)}</td>
+      <td class="tok-num">${fmtNum(row.completion_tokens)}</td>
+      <td class="tok-num">${fmtNum(row.total_tokens)}</td>
+      <td class="tok-cost">$${cost.toFixed(4)}</td>
+      <td class="tok-num">${escHtml(dur)}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+function rerenderTokenCosts() {
+  if (_tokensData.length) renderTokensTable();
+}
+
+function fmtNum(n) {
+  if (n == null) return '—';
+  return Number(n).toLocaleString('en-US');
 }
 
 // ------------------------------------------------------------------ utils

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,10 @@ database at `~/.agent-container/runs.db` via `RunLogger`. The `initiated_by` col
 the source. `RunStore` (read-side) is used by the dashboard's `GET /api/runs` to surface the
 full history in one list.
 
+Token usage (`prompt_tokens`, `completion_tokens`, `total_tokens`) is written to the same
+`runs` row when the opencode proxy emits its `[runner] token_usage:` summary line. The
+`GET /api/tokens` endpoint surfaces these columns for the dashboard Tokens tab.
+
 ## opencode adapter (thin proxy)
 
 opencode v1.14+ uses the OpenAI Responses API (`POST /v1/responses`). No self-hosted inference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,14 +139,19 @@ Step 5 — Container destroyed
 
 ```
 AgentTaskSpec
-  repo, task, base_branch, image, env, timeout_seconds
+  repo, task, base_branch, image, env
+  timeout_coldstart  — warmup probe budget (default 300s)
+  timeout_agent      — agent execution budget, sets OPENCODE_TIMEOUT (default 600s)
+  timeout_tests      — test suite budget (default 120s)
+  total_timeout      — computed: sum of all three (Modal sandbox lifetime)
   backend, create_pr, run_tests
   initiated_by ("cli" | "dashboard")
   run_id (optional — dashboard pre-allocates; CLI auto-generates)
         ↓
 ModalSandbox.run(spec)
-  → RunLogger.create(...)  writes run row to ~/.agent-container/runs.db
-  → modal.Sandbox.create() boots ephemeral container
+  → RunLogger.create(...)    writes run row to ~/.agent-container/runs.db
+  → _wait_for_inference(...) WARMING: polls /v1/models for up to timeout_coldstart
+  → modal.Sandbox.create()   BOOTING: container lifetime = total_timeout
         ↓
 AgentTaskResult
   success, run_id, branch, pr_url, diff, diff_stat, duration_seconds, error, backend

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -88,11 +88,11 @@ pytest tests/integration/ -v -m integration  # integration only
 | E2e | Real model, fixture repo, full PR creation | Modal + model endpoint | Nightly |
 
 **Unit tests mock everything external.** The Modal SDK and subprocess are patched. Add unit
-tests first when adding a feature. 263 tests run in < 2 seconds.
+tests first when adding a feature. 271 tests run in < 2 seconds.
 
 The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the Responses API →
-Chat Completions conversion layer, including the SSE event sequence, tool conversion, and
-message reshaping that underpins every opencode run.
+Chat Completions conversion layer, including the SSE event sequence, tool conversion,
+message reshaping, and token accumulation that underpins every opencode run.
 
 **Integration tests use `--backend stub`.** The stub backend echoes the task and exits 0 — no
 model tokens spent, no code changed. Exercises the full sandbox lifecycle at near-zero cost.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,12 +83,16 @@ pytest tests/integration/ -v -m integration  # integration only
 
 | Layer | What it tests | External services | When it runs |
 |---|---|---|---|
-| Unit | Config, spec, result, sandbox, git ops (all mocked) | None | Every commit |
+| Unit | Config, spec, result, sandbox, git ops, proxy, CLI (all mocked) | None | Every commit |
 | Integration | Full Modal sandbox lifecycle, stub agent | Modal | Every PR |
 | E2e | Real model, fixture repo, full PR creation | Modal + model endpoint | Nightly |
 
 **Unit tests mock everything external.** The Modal SDK and subprocess are patched. Add unit
-tests first when adding a feature.
+tests first when adding a feature. 263 tests run in < 2 seconds.
+
+The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the Responses API →
+Chat Completions conversion layer, including the SSE event sequence, tool conversion, and
+message reshaping that underpins every opencode run.
 
 **Integration tests use `--backend stub`.** The stub backend echoes the task and exits 0 — no
 model tokens spent, no code changed. Exercises the full sandbox lifecycle at near-zero cost.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -15,21 +15,23 @@ make dashboard
 
 ```
 ┌─────────────────────┬────────────────────────────────────────────────┐
-│  Left sidebar       │  Run list (main area)                          │
-│                     │                                                │
-│  ┌───────────────┐  │  ▶ ● run-20260501-123456  org/repo  aider  cli │
-│  │ Model server  │  │  ▶ ● run-20260501-120000  org/repo  opencode  dashboard │
-│  │ profile ▾     │  │  ▼ ● run-20260501-110000  org/repo  aider  cli │
-│  │ [Deploy]      │  │    ┌─ expanded ─────────────────────────────┐  │
-│  └───────────────┘  │    │ branch: main  task: fix pagination...  │  │
-│                     │    │ 12:01:04 ▶ BOOTING                     │  │
-│  ┌───────────────┐  │    │ 12:01:08 ▶ CLONING                     │  │
+│  Left sidebar       │  [ Runs ] [ Tokens ]  ← tab bar                │
+│                     ├────────────────────────────────────────────────┤
+│  ┌───────────────┐  │  RUNS TAB                                      │
+│  │ Model server  │  │  ▶ ● run-20260501-123456  org/repo  aider  cli │
+│  │ profile ▾     │  │  ▶ ● run-20260501-120000  org/repo  opencode   │
+│  │ [Deploy]      │  │  ▼ ● run-20260501-110000  org/repo  aider      │
+│  └───────────────┘  │    ┌─ expanded ─────────────────────────────┐  │
+│                     │    │ branch: main  task: fix pagination...  │  │
+│  ┌───────────────┐  │    │ 12:01:04 ▶ BOOTING                     │  │
 │  │ New run       │  │    │ 12:01:15 ▶ RUNNING                     │  │
 │  │ repo ______   │  │    │ 12:02:30 ✓ DONE  +12 −3                │  │
 │  │ task ______   │  │    └────────────────────────────────────────┘  │
-│  │ backend ▾     │  │                                                │
-│  │ [Start run]   │  │                                                │
-│  └───────────────┘  │                                                │
+│  │ backend ▾     │  ├────────────────────────────────────────────────┤
+│  │ [Start run]   │  │  TOKENS TAB                                    │
+│  └───────────────┘  │  backend ▾  from ____  to ____  $/1M [1.00]   │
+│                     │  Run ID  Repo  Backend  Prompt  Completion  …  │
+│                     │  run-20… org/… opencode  12,345   1,234  …     │
 └─────────────────────┴────────────────────────────────────────────────┘
 ```
 
@@ -37,7 +39,11 @@ make dashboard
 - **Model server panel** — profile/model selector and Deploy button (see [Serve panel](#serve-panel))
 - **New run form** — repo URL, task, backend, base branch, options
 
-**Main area** is a full-width scrollable list of run rows. Each row is collapsible:
+**Main area** has a tab bar at the top:
+
+### Runs tab
+
+Full-width scrollable list of run rows. Each row is collapsible:
 
 | State | What you see |
 |---|---|
@@ -46,6 +52,31 @@ make dashboard
 
 Click anywhere on a row summary to expand or collapse it. New runs auto-expand and stream
 logs as they arrive. Rows remain in the list after completion — collapse them to keep the view clean.
+
+### Tokens tab
+
+Per-run token consumption for all completed runs that have token data (opencode via the Responses
+API proxy; other backends emit no usage data unless they log the `[runner] token_usage:` line).
+
+| Column | Description |
+|---|---|
+| Run ID | Links the row to the run |
+| Repository | Short form (org/repo) |
+| Backend | Badge (aider / opencode / …) |
+| Outcome | success / error / failed |
+| Prompt tokens | Input tokens charged |
+| Completion tokens | Output tokens charged |
+| Total tokens | Sum |
+| Est. cost | `total_tokens / 1M × rate` — rate is configurable in the toolbar |
+| Duration | Wall-clock seconds for the run |
+
+**Toolbar controls:**
+- **Backend filter** — narrow to one backend for apples-to-apples comparisons
+- **From / To date pickers** — restrict to a date range
+- **$/1M tokens** — cost rate input; updating it recalculates the Est. cost column live without reloading data
+- **Summary bar** — shows `N runs · X total tokens · est. $Y` for the current filtered set
+
+Click any column header to sort. Clicking the same header again reverses the sort direction.
 
 ## `initiated_by` badge
 
@@ -101,6 +132,38 @@ The dashboard is a Backend-for-Frontend: all Modal and SQLite concerns stay serv
 | `GET` | `/api/runs/{id}` | Single run metadata (SQLite + live phase if active) |
 | `DELETE` | `/api/runs/{id}` | Cancel a run (best-effort) |
 | `GET` | `/api/runs/{id}/stream` | SSE stream of lifecycle events (dashboard runs only) |
+| `GET` | `/api/runs/{id}/events` | Past log events from SQLite (replay on page load) |
+
+### Tokens
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/tokens` | Runs with token data, sorted by `total_tokens` desc |
+
+**Query parameters for `GET /api/tokens`:**
+
+| Param | Example | Description |
+|---|---|---|
+| `backend` | `opencode` | Filter by backend name |
+| `date_from` | `2026-05-01` | Lower bound on `started_at` (inclusive) |
+| `date_to` | `2026-05-03` | Upper bound on `started_at` (inclusive) |
+
+**Response row shape:**
+
+```json
+{
+  "run_id":            "run-20260503-120000-abc123",
+  "repo":              "https://github.com/org/repo",
+  "task":              "Fix the login bug",
+  "backend":           "opencode",
+  "started_at":        "2026-05-03T12:00:00+00:00",
+  "outcome":           "success",
+  "prompt_tokens":     12345,
+  "completion_tokens": 678,
+  "total_tokens":      13023,
+  "duration_s":        142.3
+}
+```
 
 **`POST /api/runs` body:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,8 @@ Your terminal / dashboard / Claude Code session
   agent-run CLI  (or Python API, or MCP tool)
         ↓
   Modal Sandbox  ← ephemeral container, destroyed after each run
-  WARMING → BOOTING → CLONING → RUNNING → TESTING → PR
+  WARMING (timeout_coldstart) → BOOTING → CLONING
+  → RUNNING (timeout_agent) → TESTING (timeout_tests) → PR
         ↓
   Coding agent   ← aider / opencode / Claude Code CLI / Gemini CLI
         ↓
@@ -58,7 +59,8 @@ Your terminal / dashboard / Claude Code session
   GitHub / GitLab PR
 ```
 
-See [Architecture](architecture.md) for the full picture.
+Each pipeline phase has its own timeout budget — WARMING failures are diagnosed separately from
+agent hangs. See [Architecture](architecture.md) for the full picture.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,13 +34,14 @@ Pure Responses API ↔ Chat Completions adapter, zero model-specific code.
 - `make example BACKEND=opencode` produces a real diff and opens a PR (verified: fixture PR #12)
 
 ### Phase 2.5 — Hardening + observability (done)
-Proxy correctness, per-phase timeouts, CI guards, test coverage.
+Proxy correctness, per-phase timeouts, CI guards, test coverage, token tracking.
 
 - [#64](https://github.com/dvdthecoder/agent-container/issues/64) Per-phase timeouts: `timeout_coldstart` / `timeout_agent` / `timeout_tests` replace the single `timeout_seconds` — each phase has its own budget; Modal sandbox lifetime = sum of all three
 - [#65](https://github.com/dvdthecoder/agent-container/issues/65) Warmup probe uses `timeout_coldstart` budget — cold-start burns are isolated from agent execution time
 - [#67](https://github.com/dvdthecoder/agent-container/issues/67) 24 unit tests for Responses API proxy — `_convert_tools`, `_convert_input_items`, `_translate_chat_response`, `_stream_chat_to_responses`, full SSE event sequence
 - CI guard: `scripts/check_container_imports.py` blocks dev-only packages (`pytest`, `ruff`, etc.) from being imported in `modal/` or `agent/` at commit time
 - opencode pinned to `1.14.31` — deliberate upgrade path with proxy compatibility check
+- [#130](https://github.com/dvdthecoder/agent-container/issues/130) Token usage tab: proxy accumulates `usage` from every Chat Completions turn; persisted to SQLite; dashboard **Tokens** tab shows per-run prompt/completion/total tokens with live cost estimate and backend/date filters; 271 unit tests total
 
 ### Phase 3 — SGLang validation (done)
 SGLang deployed as a separate Modal app (`agent-container-serve-sglang`); tool calling confirmed working with `hermes` parser.
@@ -54,22 +55,13 @@ SGLang deployed as a separate Modal app (`agent-container-serve-sglang`); tool c
 
 ---
 
-## In progress
-
-| Task |
-|------|
-| Fix fixture repo — add `.gitignore` for `__pycache__` so pyc files stop appearing in PR diffs |
-
----
-
 ## Planned
 
-### Phase 4 — Model expansion + observability
-Broaden the model menu and make runs observable beyond the final PR.
+### Phase 4 — Model expansion + richer observability
+Broaden the model menu and deepen run observability.
 
 | Issue | Task |
 |---|---|
-| [#130](https://github.com/dvdthecoder/agent-container/issues/130) | Token usage tab in dashboard — per-run prompt/completion/total tokens, cost estimate, filter by backend/date |
 | [#113](https://github.com/dvdthecoder/agent-container/issues/113) | Add Qwen3-Coder and Gemma 4 model profiles to `serve.py` (vLLM) |
 | [#114](https://github.com/dvdthecoder/agent-container/issues/114) | Docs: cost and quality comparison — self-hosted LLMs vs Claude API |
 | [#115](https://github.com/dvdthecoder/agent-container/issues/115) | Docs: step-by-step guide for adding a new model profile |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,15 @@ Pure Responses API ↔ Chat Completions adapter, zero model-specific code.
   infinite bash loop after the file is written
 - `make example BACKEND=opencode` produces a real diff and opens a PR (verified: fixture PR #12)
 
+### Phase 2.5 — Hardening + observability (done)
+Proxy correctness, per-phase timeouts, CI guards, test coverage.
+
+- [#64](https://github.com/dvdthecoder/agent-container/issues/64) Per-phase timeouts: `timeout_coldstart` / `timeout_agent` / `timeout_tests` replace the single `timeout_seconds` — each phase has its own budget; Modal sandbox lifetime = sum of all three
+- [#65](https://github.com/dvdthecoder/agent-container/issues/65) Warmup probe uses `timeout_coldstart` budget — cold-start burns are isolated from agent execution time
+- [#67](https://github.com/dvdthecoder/agent-container/issues/67) 24 unit tests for Responses API proxy — `_convert_tools`, `_convert_input_items`, `_translate_chat_response`, `_stream_chat_to_responses`, full SSE event sequence
+- CI guard: `scripts/check_container_imports.py` blocks dev-only packages (`pytest`, `ruff`, etc.) from being imported in `modal/` or `agent/` at commit time
+- opencode pinned to `1.14.31` — deliberate upgrade path with proxy compatibility check
+
 ### Phase 3 — SGLang validation (done)
 SGLang deployed as a separate Modal app (`agent-container-serve-sglang`); tool calling confirmed working with `hermes` parser.
 
@@ -60,6 +69,7 @@ Broaden the model menu and make runs observable beyond the final PR.
 
 | Issue | Task |
 |---|---|
+| [#130](https://github.com/dvdthecoder/agent-container/issues/130) | Token usage tab in dashboard — per-run prompt/completion/total tokens, cost estimate, filter by backend/date |
 | [#113](https://github.com/dvdthecoder/agent-container/issues/113) | Add Qwen3-Coder and Gemma 4 model profiles to `serve.py` (vLLM) |
 | [#114](https://github.com/dvdthecoder/agent-container/issues/114) | Docs: cost and quality comparison — self-hosted LLMs vs Claude API |
 | [#115](https://github.com/dvdthecoder/agent-container/issues/115) | Docs: step-by-step guide for adding a new model profile |

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -9,6 +9,7 @@ ModalSandbox is the orchestrator.  Domain logic lives in dedicated modules:
 
 from __future__ import annotations
 
+import re
 import sys
 import time
 import urllib.error
@@ -145,8 +146,18 @@ class ModalSandbox:
                 backend = get_backend(spec.backend)
                 agent_timeout = float(spec.timeout_agent)
 
+                _token_usage_re = re.compile(
+                    r"\[runner\] token_usage: prompt=(\d+) completion=(\d+) total=(\d+)"
+                )
+
                 def _on_log(label: str, line: str) -> None:
                     _emit("log", text=line, source=label)
+                    m = _token_usage_re.search(line)
+                    if m:
+                        try:
+                            logger.set_token_usage(int(m[1]), int(m[2]), int(m[3]))
+                        except Exception:  # noqa: BLE001, S110
+                            pass
 
                 agent_output, exit_code = runner.run_agent(
                     sb,

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -128,7 +128,11 @@ class ModalSandbox:
         try:
             try:
                 _emit("phase", phase="WARMING")
-                _wait_for_inference(self.config.openai_base_url, start)
+                _wait_for_inference(
+                    self.config.openai_base_url,
+                    start,
+                    max_wait=float(spec.timeout_coldstart),
+                )
 
                 _emit("phase", phase="BOOTING")
                 sb = self._create(spec)
@@ -139,9 +143,7 @@ class ModalSandbox:
 
                 _emit("phase", phase="RUNNING")
                 backend = get_backend(spec.backend)
-                # Give the agent spec.timeout_seconds - 60s (same headroom
-                # given to OPENCODE_TIMEOUT) before we hard-terminate.
-                agent_timeout = float(spec.timeout_seconds - 60)
+                agent_timeout = float(spec.timeout_agent)
 
                 def _on_log(label: str, line: str) -> None:
                     _emit("log", text=line, source=label)
@@ -253,15 +255,14 @@ class ModalSandbox:
             **self.config.env_for_backend(spec.backend),
             **spec.env,
         }
-        # Give the opencode runner 60s less than the sandbox timeout so it
-        # can exit cleanly before Modal forcefully kills the container.
-        env.setdefault("OPENCODE_TIMEOUT", str(spec.timeout_seconds - 60))
+        # opencode runner budget = timeout_agent (already excludes cold-start).
+        env.setdefault("OPENCODE_TIMEOUT", str(spec.timeout_agent))
         # Single shared app — all sandbox runs attach to the same app so
         # Modal doesn't accumulate one app per run (the original leak).
         app = modal.App.lookup("agent-container-sandbox", create_if_missing=True)
         return modal.Sandbox.create(
             image=image,
-            timeout=spec.timeout_seconds,
+            timeout=spec.total_timeout,
             secrets=[modal.Secret.from_dict(env)] if env else [],
             app=app,
             cpu=spec.cpu,

--- a/sandbox/spec.py
+++ b/sandbox/spec.py
@@ -14,7 +14,13 @@ class AgentTaskSpec:
     base_branch: str = "main"
     image: str | None = None
     env: dict[str, str] = field(default_factory=dict)
-    timeout_seconds: int = 600
+    # Per-phase timeouts (seconds).  Use these instead of the deprecated
+    # timeout_seconds alias.
+    timeout_coldstart: int = 300  # warmup probe: poll serve endpoint until ready
+    timeout_agent: int = 600  # agent execution budget (passed to OPENCODE_TIMEOUT)
+    timeout_tests: int = 120  # test suite execution budget
+    # Deprecated: sets timeout_agent if non-zero.  Kept for CLI / dashboard compat.
+    timeout_seconds: int = 0
     cpu: float = 2.0  # vCPUs allocated to the sandbox (Modal default 0.1 is too low)
     memory: int = 1024  # MB of RAM for the sandbox (Modal default 128 MB causes OOM)
     create_pr: bool = True
@@ -38,8 +44,22 @@ class AgentTaskSpec:
         if not self.repo.startswith(("https://", "git@")):
             raise ValueError(f"'repo' must be a full URL (https:// or git@...), got: {self.repo!r}")
 
-        if self.timeout_seconds < 1:
-            raise ValueError(f"timeout_seconds must be >= 1, got {self.timeout_seconds}")
+        # Backwards compat: timeout_seconds overrides timeout_agent.
+        if self.timeout_seconds > 0:
+            self.timeout_agent = self.timeout_seconds
+
+        for name, val in (
+            ("timeout_coldstart", self.timeout_coldstart),
+            ("timeout_agent", self.timeout_agent),
+            ("timeout_tests", self.timeout_tests),
+        ):
+            if val < 1:
+                raise ValueError(f"{name} must be >= 1, got {val}")
+
+    @property
+    def total_timeout(self) -> int:
+        """Total sandbox lifetime: coldstart + agent + tests."""
+        return self.timeout_coldstart + self.timeout_agent + self.timeout_tests
 
     def resolved_task(self) -> str:
         """Return the task string, reading from file if task_file was provided."""

--- a/tests/unit/test_log_store.py
+++ b/tests/unit/test_log_store.py
@@ -231,3 +231,58 @@ def test_store_raises_when_db_missing(tmp_path):
     store = RunStore(db_path=tmp_path / "nonexistent.db")
     with pytest.raises(FileNotFoundError):
         store.list_runs()
+
+
+# ------------------------------------------------------------------ token usage
+
+
+def test_set_token_usage_persisted(logger, store):
+    logger.set_token_usage(prompt_tokens=1234, completion_tokens=567, total_tokens=1801)
+    logger.finish("success")
+    run = store.get_run(logger.run_id)
+    assert run is not None
+    assert run.prompt_tokens == 1234
+    assert run.completion_tokens == 567
+    assert run.total_tokens == 1801
+
+
+def test_token_fields_default_to_none(logger, store):
+    logger.finish("success")
+    run = store.get_run(logger.run_id)
+    assert run is not None
+    assert run.prompt_tokens is None
+    assert run.completion_tokens is None
+    assert run.total_tokens is None
+
+
+def test_migration_adds_token_columns(tmp_path):
+    """A DB created without token columns should gain them after migration."""
+    import sqlite3
+
+    db = tmp_path / "old.db"
+    # Create a schema without the new columns, simulating an existing DB.
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE runs ("
+        "run_id TEXT PRIMARY KEY, repo TEXT NOT NULL, task TEXT NOT NULL,"
+        " backend TEXT NOT NULL, initiated_by TEXT NOT NULL DEFAULT 'cli',"
+        " base_branch TEXT NOT NULL DEFAULT 'main',"
+        " timeout_seconds INTEGER NOT NULL DEFAULT 600,"
+        " started_at TEXT NOT NULL, finished_at TEXT, outcome TEXT,"
+        " branch TEXT, pr_url TEXT, duration_s REAL, sandbox_id TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    # Opening a RunLogger on the old DB triggers migration.
+    lg = RunLogger.create(
+        repo="https://github.com/org/repo", task="fix it", backend="opencode", db_path=db
+    )
+    lg.set_token_usage(100, 50, 150)
+    lg.close()
+
+    store = RunStore(db_path=db)
+    run = store.get_run(lg.run_id)
+    assert run is not None
+    assert run.prompt_tokens == 100
+    assert run.total_tokens == 150

--- a/tests/unit/test_responses_proxy.py
+++ b/tests/unit/test_responses_proxy.py
@@ -1,0 +1,350 @@
+"""Unit tests for the Responses API → Chat Completions proxy.
+
+The proxy logic lives in agent/opencode_runner.py (_ProxyHandler and the
+conversion helpers).  These tests cover the pure conversion functions and the
+translation methods without spinning up an HTTP server.
+
+All tests are self-contained — no network calls, no Modal, no external
+services required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+
+# Import the pure functions and the handler class directly.  The module-level
+# globals (TASK, BASE_URL, etc.) are fine — they just read from env/argv.
+from agent.opencode_runner import (
+    _convert_input_items,
+    _convert_tools,
+    _ProxyHandler,
+)
+
+# ---------------------------------------------------------------------------
+# _convert_tools
+# ---------------------------------------------------------------------------
+
+
+class TestConvertTools:
+    def test_flat_function_wrapped_in_function_key(self):
+        tools = [{"type": "function", "name": "read", "parameters": {"type": "object"}}]
+        result = _convert_tools(tools)
+        assert result == [
+            {
+                "type": "function",
+                "function": {"name": "read", "parameters": {"type": "object"}},
+            }
+        ]
+
+    def test_already_wrapped_tool_passed_through(self):
+        tool = {"type": "function", "function": {"name": "edit", "parameters": {}}}
+        result = _convert_tools([tool])
+        assert result == [tool]
+
+    def test_non_dict_skipped(self):
+        result = _convert_tools(["not-a-dict", None])  # type: ignore[list-item]
+        assert result == []
+
+    def test_empty_list(self):
+        assert _convert_tools([]) == []
+
+    def test_multiple_tools_all_converted(self):
+        tools = [
+            {"type": "function", "name": "read", "parameters": {}},
+            {"type": "function", "name": "edit", "parameters": {}},
+        ]
+        result = _convert_tools(tools)
+        assert len(result) == 2
+        assert result[0]["function"]["name"] == "read"
+        assert result[1]["function"]["name"] == "edit"
+
+
+# ---------------------------------------------------------------------------
+# _convert_input_items
+# ---------------------------------------------------------------------------
+
+
+class TestConvertInputItems:
+    def test_string_item_becomes_user_message(self):
+        result = _convert_input_items(["hello world"])
+        assert result == [{"role": "user", "content": "hello world"}]
+
+    def test_plain_message_item(self):
+        item = {"type": "message", "role": "user", "content": "fix it"}
+        result = _convert_input_items([item])
+        assert result == [{"role": "user", "content": "fix it"}]
+
+    def test_developer_role_mapped_to_system(self):
+        item = {"type": "message", "role": "developer", "content": "You are a coder."}
+        result = _convert_input_items([item])
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are a coder."
+
+    def test_tool_result_becomes_tool_message(self):
+        item = {"type": "tool_result", "call_id": "call_abc", "output": "file contents"}
+        result = _convert_input_items([item])
+        assert result == [{"role": "tool", "tool_call_id": "call_abc", "content": "file contents"}]
+
+    def test_function_call_becomes_assistant_with_tool_calls(self):
+        item = {
+            "type": "function_call",
+            "id": "call_123",
+            "call_id": "call_123",
+            "name": "read",
+            "arguments": '{"path": "/foo.py"}',
+        }
+        result = _convert_input_items([item])
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "assistant"
+        tc = msg["tool_calls"][0]
+        assert tc["id"] == "call_123"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "read"
+        assert tc["function"]["arguments"] == '{"path": "/foo.py"}'
+
+    def test_list_content_joined(self):
+        item = {
+            "type": "message",
+            "role": "user",
+            "content": [{"text": "hello"}, {"text": "world"}],
+        }
+        result = _convert_input_items([item])
+        assert result[0]["content"] == "hello world"
+
+    def test_unknown_type_serialized_as_json(self):
+        item = {"type": "mystery", "role": "user", "data": 42}
+        result = _convert_input_items([item])
+        assert result[0]["role"] == "user"
+        # content is the JSON serialisation of the whole item
+        parsed = json.loads(result[0]["content"])
+        assert parsed["type"] == "mystery"
+
+    def test_empty_list(self):
+        assert _convert_input_items([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _ProxyHandler._translate_chat_response
+# ---------------------------------------------------------------------------
+
+
+def _make_handler() -> _ProxyHandler:
+    """Return a _ProxyHandler instance without wiring up an HTTP server."""
+    handler = _ProxyHandler.__new__(_ProxyHandler)
+    return handler
+
+
+class TestTranslateChatResponse:
+    def _chat_response(
+        self,
+        text: str = "",
+        tool_calls: list | None = None,
+        model: str = "qwen2.5",
+    ) -> bytes:
+        message: dict = {"content": text or None, "role": "assistant"}
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        return json.dumps(
+            {
+                "id": "chatcmpl-abc",
+                "model": model,
+                "choices": [{"message": message}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            }
+        ).encode()
+
+    def test_text_response_produces_message_output(self):
+        handler = _make_handler()
+        raw = self._chat_response(text="Here is the fix.")
+        result = json.loads(handler._translate_chat_response(raw))
+
+        assert result["object"] == "response"
+        assert len(result["output"]) == 1
+        item = result["output"][0]
+        assert item["type"] == "message"
+        assert item["content"][0]["text"] == "Here is the fix."
+
+    def test_tool_call_response_produces_function_call_output(self):
+        handler = _make_handler()
+        raw = self._chat_response(
+            tool_calls=[
+                {
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {"name": "edit", "arguments": '{"path":"/a.py"}'},
+                }
+            ]
+        )
+        result = json.loads(handler._translate_chat_response(raw))
+
+        assert result["object"] == "response"
+        fn_items = [o for o in result["output"] if o["type"] == "function_call"]
+        assert len(fn_items) == 1
+        fc = fn_items[0]
+        assert fc["name"] == "edit"
+        assert fc["call_id"] == "call_xyz"
+        assert fc["arguments"] == '{"path":"/a.py"}'
+
+    def test_empty_response_produces_empty_message(self):
+        handler = _make_handler()
+        raw = self._chat_response(text="")
+        result = json.loads(handler._translate_chat_response(raw))
+
+        assert len(result["output"]) == 1
+        assert result["output"][0]["type"] == "message"
+
+    def test_usage_field_preserved(self):
+        handler = _make_handler()
+        raw = self._chat_response(text="hi")
+        result = json.loads(handler._translate_chat_response(raw))
+
+        assert result["usage"]["prompt_tokens"] == 10
+        assert result["usage"]["total_tokens"] == 15
+
+    def test_invalid_json_returned_as_is(self):
+        handler = _make_handler()
+        raw = b"not json"
+        result = handler._translate_chat_response(raw)
+        assert result == raw
+
+
+# ---------------------------------------------------------------------------
+# _ProxyHandler._stream_chat_to_responses
+# ---------------------------------------------------------------------------
+
+
+def _sse_lines(*chunks: dict) -> list[bytes]:
+    """Build SSE byte lines from a sequence of Chat Completions delta chunks."""
+    lines = []
+    for chunk in chunks:
+        lines.append(f"data: {json.dumps(chunk)}\n".encode())
+    lines.append(b"data: [DONE]\n")
+    return lines
+
+
+def _delta_chunk(
+    text: str | None = None,
+    tool_index: int | None = None,
+    tool_id: str | None = None,
+    tool_name: str | None = None,
+    tool_args: str | None = None,
+) -> dict:
+    delta: dict = {}
+    if text is not None:
+        delta["content"] = text
+    if tool_index is not None:
+        tc: dict = {"index": tool_index}
+        if tool_id:
+            tc["id"] = tool_id
+        fn: dict = {}
+        if tool_name:
+            fn["name"] = tool_name
+        if tool_args:
+            fn["arguments"] = tool_args
+        if fn:
+            tc["function"] = fn
+        delta["tool_calls"] = [tc]
+    return {"choices": [{"delta": delta}]}
+
+
+def _capture_streaming_sse(sse_lines: list[bytes]) -> list[dict]:
+    """Run _stream_chat_to_responses and collect parsed SSE events."""
+    handler = _make_handler()
+    handler.send_response = MagicMock()
+    handler.send_header = MagicMock()
+    handler.end_headers = MagicMock()
+    buf = io.BytesIO()
+    handler.wfile = buf
+
+    mock_resp = MagicMock()
+    mock_resp.__iter__ = MagicMock(return_value=iter(sse_lines))
+
+    handler._stream_chat_to_responses(mock_resp)
+
+    buf.seek(0)
+    events = []
+    for raw in buf.read().decode().split("\n\n"):
+        raw = raw.strip()
+        if raw.startswith("data:"):
+            try:
+                events.append(json.loads(raw[5:].strip()))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+class TestStreamChatToResponses:
+    def test_text_delta_emitted_as_output_text_delta(self):
+        lines = _sse_lines(
+            _delta_chunk(text="Hello"),
+            _delta_chunk(text=" world"),
+        )
+        events = _capture_streaming_sse(lines)
+
+        delta_events = [e for e in events if e.get("type") == "response.output_text.delta"]
+        assert len(delta_events) == 2
+        assert delta_events[0]["delta"] == "Hello"
+        assert delta_events[1]["delta"] == " world"
+
+    def test_tool_call_emits_full_event_sequence(self):
+        lines = _sse_lines(
+            _delta_chunk(tool_index=0, tool_id="call_1", tool_name="read", tool_args=""),
+            _delta_chunk(tool_index=0, tool_args='{"path":"/a.py"}'),
+        )
+        events = _capture_streaming_sse(lines)
+
+        types = [e.get("type") for e in events]
+        assert "response.output_item.added" in types
+        assert "response.function_call_arguments.delta" in types
+        assert "response.function_call_arguments.done" in types
+        assert "response.output_item.done" in types
+        assert "response.completed" in types
+
+    def test_response_completed_emitted_after_tool_call(self):
+        lines = _sse_lines(
+            _delta_chunk(tool_index=0, tool_id="call_99", tool_name="edit", tool_args="{}"),
+        )
+        events = _capture_streaming_sse(lines)
+
+        completed = [e for e in events if e.get("type") == "response.completed"]
+        assert len(completed) == 1
+        output = completed[0]["response"]["output"]
+        fn_items = [o for o in output if o.get("type") == "function_call"]
+        assert len(fn_items) == 1
+        assert fn_items[0]["name"] == "edit"
+
+    def test_response_completed_emitted_for_text_only(self):
+        lines = _sse_lines(
+            _delta_chunk(text="Done."),
+        )
+        events = _capture_streaming_sse(lines)
+
+        completed = [e for e in events if e.get("type") == "response.completed"]
+        assert len(completed) == 1
+
+    def test_arguments_accumulated_across_chunks(self):
+        lines = _sse_lines(
+            _delta_chunk(tool_index=0, tool_id="c1", tool_name="read", tool_args=""),
+            _delta_chunk(tool_index=0, tool_args='{"pa'),
+            _delta_chunk(tool_index=0, tool_args='th":"/x"}'),
+        )
+        events = _capture_streaming_sse(lines)
+
+        done_events = [
+            e for e in events if e.get("type") == "response.function_call_arguments.done"
+        ]
+        assert len(done_events) == 1
+        assert done_events[0]["arguments"] == '{"path":"/x"}'
+
+    def test_empty_stream_produces_empty_message_in_completed(self):
+        lines = [b"data: [DONE]\n"]
+        events = _capture_streaming_sse(lines)
+
+        completed = [e for e in events if e.get("type") == "response.completed"]
+        assert len(completed) == 1
+        output = completed[0]["response"]["output"]
+        assert len(output) == 1
+        assert output[0]["type"] == "message"

--- a/tests/unit/test_responses_proxy.py
+++ b/tests/unit/test_responses_proxy.py
@@ -16,7 +16,9 @@ from unittest.mock import MagicMock
 
 # Import the pure functions and the handler class directly.  The module-level
 # globals (TASK, BASE_URL, etc.) are fine — they just read from env/argv.
+import agent.opencode_runner as _proxy_mod
 from agent.opencode_runner import (
+    _accumulate_tokens,
     _convert_input_items,
     _convert_tools,
     _ProxyHandler,
@@ -348,3 +350,58 @@ class TestStreamChatToResponses:
         output = completed[0]["response"]["output"]
         assert len(output) == 1
         assert output[0]["type"] == "message"
+
+
+# ---------------------------------------------------------------------------
+# Token accumulation
+# ---------------------------------------------------------------------------
+
+
+def _reset_token_counts():
+    """Reset the module-level accumulator between tests."""
+    with _proxy_mod._token_lock:
+        _proxy_mod._token_counts["prompt"] = 0
+        _proxy_mod._token_counts["completion"] = 0
+
+
+class TestTokenAccumulation:
+    def setup_method(self):
+        _reset_token_counts()
+
+    def test_accumulate_adds_prompt_and_completion(self):
+        _accumulate_tokens({"prompt_tokens": 100, "completion_tokens": 50})
+        with _proxy_mod._token_lock:
+            assert _proxy_mod._token_counts["prompt"] == 100
+            assert _proxy_mod._token_counts["completion"] == 50
+
+    def test_accumulate_sums_across_calls(self):
+        _accumulate_tokens({"prompt_tokens": 100, "completion_tokens": 50})
+        _accumulate_tokens({"prompt_tokens": 200, "completion_tokens": 30})
+        with _proxy_mod._token_lock:
+            assert _proxy_mod._token_counts["prompt"] == 300
+            assert _proxy_mod._token_counts["completion"] == 80
+
+    def test_accumulate_noop_on_empty_dict(self):
+        _accumulate_tokens({})
+        with _proxy_mod._token_lock:
+            assert _proxy_mod._token_counts["prompt"] == 0
+
+    def test_accumulate_noop_on_none(self):
+        _accumulate_tokens(None)  # type: ignore[arg-type]
+        with _proxy_mod._token_lock:
+            assert _proxy_mod._token_counts["prompt"] == 0
+
+    def test_stream_picks_up_usage_chunk(self):
+        """A stream chunk with a top-level 'usage' field accumulates tokens."""
+        usage_chunk = {
+            "choices": [{"delta": {}}],
+            "usage": {"prompt_tokens": 42, "completion_tokens": 8, "total_tokens": 50},
+        }
+        lines = [
+            f"data: {json.dumps(usage_chunk)}\n".encode(),
+            b"data: [DONE]\n",
+        ]
+        _capture_streaming_sse(lines)
+        with _proxy_mod._token_lock:
+            assert _proxy_mod._token_counts["prompt"] == 42
+            assert _proxy_mod._token_counts["completion"] == 8

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -210,15 +210,25 @@ def test_push_failure_returns_failed_result(mock_create):
 
 
 @patch("sandbox.sandbox.modal.Sandbox.create")
-def test_run_passes_timeout_to_sandbox(mock_create):
+def test_run_passes_total_timeout_to_sandbox(mock_create):
     sb = MagicMock()
     mock_create.return_value = sb
     sb.exec.return_value = _make_proc()
 
-    ModalSandbox(_config()).run(_spec(timeout_seconds=120))
+    from sandbox.spec import AgentTaskSpec
+
+    spec = AgentTaskSpec(
+        repo="https://github.com/org/repo",
+        task="fix it",
+        timeout_coldstart=60,
+        timeout_agent=120,
+        timeout_tests=30,
+    )
+    ModalSandbox(_config()).run(spec)
 
     _, kwargs = mock_create.call_args
-    assert kwargs["timeout"] == 120
+    # Modal sandbox timeout = sum of all phases
+    assert kwargs["timeout"] == 60 + 120 + 30
 
 
 @patch("sandbox.sandbox.modal.Sandbox.create")

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -36,20 +36,36 @@ class TestAgentTaskSpecValidation:
         with pytest.raises(ValueError, match="full URL"):
             AgentTaskSpec(repo="org/repo", task="fix it")
 
-    def test_raises_when_timeout_is_zero(self):
-        with pytest.raises(ValueError, match="timeout_seconds"):
+    def test_raises_when_timeout_agent_is_zero(self):
+        with pytest.raises(ValueError, match="timeout_agent"):
             AgentTaskSpec(
                 repo="https://github.com/org/repo",
                 task="fix it",
-                timeout_seconds=0,
+                timeout_agent=0,
             )
 
-    def test_raises_when_timeout_negative(self):
-        with pytest.raises(ValueError, match="timeout_seconds"):
+    def test_raises_when_timeout_agent_negative(self):
+        with pytest.raises(ValueError, match="timeout_agent"):
             AgentTaskSpec(
                 repo="https://github.com/org/repo",
                 task="fix it",
-                timeout_seconds=-1,
+                timeout_agent=-1,
+            )
+
+    def test_raises_when_timeout_coldstart_is_zero(self):
+        with pytest.raises(ValueError, match="timeout_coldstart"):
+            AgentTaskSpec(
+                repo="https://github.com/org/repo",
+                task="fix it",
+                timeout_coldstart=0,
+            )
+
+    def test_raises_when_timeout_tests_negative(self):
+        with pytest.raises(ValueError, match="timeout_tests"):
+            AgentTaskSpec(
+                repo="https://github.com/org/repo",
+                task="fix it",
+                timeout_tests=-5,
             )
 
 
@@ -60,7 +76,9 @@ class TestAgentTaskSpecDefaults:
         assert spec.base_branch == "main"
         assert spec.image is None
         assert spec.env == {}
-        assert spec.timeout_seconds == 600
+        assert spec.timeout_coldstart == 300
+        assert spec.timeout_agent == 600
+        assert spec.timeout_tests == 120
         assert spec.create_pr is True
         assert spec.backend == "opencode"
 
@@ -75,6 +93,26 @@ class TestAgentTaskSpecDefaults:
         spec = AgentTaskSpec(repo="https://github.com/org/repo", task_file=str(task_file))
 
         assert isinstance(spec.task_file, Path)
+
+
+class TestAgentTaskSpecTimeouts:
+    def test_timeout_seconds_sets_timeout_agent(self):
+        spec = AgentTaskSpec(
+            repo="https://github.com/org/repo",
+            task="fix it",
+            timeout_seconds=900,
+        )
+        assert spec.timeout_agent == 900
+
+    def test_total_timeout_sums_phases(self):
+        spec = AgentTaskSpec(
+            repo="https://github.com/org/repo",
+            task="fix it",
+            timeout_coldstart=120,
+            timeout_agent=300,
+            timeout_tests=60,
+        )
+        assert spec.total_timeout == 480
 
 
 class TestAgentTaskSpecResolvers:


### PR DESCRIPTION
## Summary
- **#64 Per-phase timeouts**: Split `timeout_seconds` into `timeout_coldstart` (300s), `timeout_agent` (600s), `timeout_tests` (120s) on `AgentTaskSpec`. Modal sandbox lifetime = sum of all three. `timeout_seconds` kept as deprecated alias for CLI/dashboard backwards compat.
- **#65 Warmup probe budget**: `_wait_for_inference` now uses `spec.timeout_coldstart` instead of the hardcoded 600s, so cold-start burns are isolated from agent execution time.
- **#67 Proxy unit tests**: 24 new tests in `tests/unit/test_responses_proxy.py` covering `_convert_tools`, `_convert_input_items`, `_translate_chat_response`, and `_stream_chat_to_responses` (including the full SSE event sequence for tool calls).

## Test plan
- [ ] `make test` passes (263 unit tests, all green)
- [ ] `ruff check .` and `ruff format --check .` clean
- [ ] Verify `timeout_seconds=N` CLI flag still works (sets `timeout_agent=N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)