### PR TITLE
feat(runner): heartbeat line every 30s during agent silence

### DIFF
--- a/agent/runner.py
+++ b/agent/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import threading
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,11 @@ if TYPE_CHECKING:
 # the iterator may never StopIterate — daemon threads will die with the
 # process, but join() would block forever.  This cap prevents that.
 _STREAM_JOIN_TIMEOUT = 10.0
+
+# Print a heartbeat line when the agent has been silent for this long.
+# Suppressed immediately when output resumes — avoids spamming the terminal
+# when aider/opencode is actively writing.
+_HEARTBEAT_INTERVAL = 30.0
 
 
 def run_agent(
@@ -38,6 +44,10 @@ def run_agent(
     *on_log(label, line)* is called for every line as it arrives — use this
     to forward live output to the dashboard without waiting for the run to finish.
 
+    A heartbeat line is printed to stderr every 30 s when the agent is silent
+    (e.g. the LLM is generating but not yet writing output), so the terminal
+    never goes completely dark during a long RUNNING phase.
+
     If *timeout* seconds elapse before the process finishes, the sandbox
     is terminated immediately and a non-zero exit code is returned.
     """
@@ -47,11 +57,19 @@ def run_agent(
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
 
+    # _last_output_time[0] is updated by _stream threads on every line.
+    # Single-element list so daemon threads can mutate it without a Lock
+    # (float assignment is atomic under the GIL).
+    _last_output_time: list[float] = [time.monotonic()]
+    _heartbeat_stop = threading.Event()
+    _run_start = time.monotonic()
+
     def _stream(source, sink: list[str], label: str) -> None:
         try:
             for raw in source:
                 line = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
                 sink.append(line)
+                _last_output_time[0] = time.monotonic()
                 sys.stderr.write(f"[sandbox:{label}] {line}")
                 sys.stderr.flush()
                 if logger is not None:
@@ -69,14 +87,34 @@ def run_agent(
             if logger is not None:
                 logger.log(f"sandbox:{label}", msg, level="warn")
 
+    def _heartbeat() -> None:
+        """Print a status line when the agent has been silent for _HEARTBEAT_INTERVAL s."""
+        tick = min(1.0, _HEARTBEAT_INTERVAL / 5)
+        while not _heartbeat_stop.wait(timeout=tick):
+            elapsed_total = time.monotonic() - _run_start
+            silent_for = time.monotonic() - _last_output_time[0]
+            if silent_for >= _HEARTBEAT_INTERVAL:
+                msg = (
+                    f"[runner] still running  elapsed={elapsed_total:.0f}s"
+                    f"  (no output for {silent_for:.0f}s)"
+                )
+                sys.stderr.write(msg + "\n")
+                sys.stderr.flush()
+                if logger is not None:
+                    logger.log("runner", msg.strip())
+                # Reset so we don't spam every second after the threshold.
+                _last_output_time[0] = time.monotonic()
+
     t_out = threading.Thread(
         target=_stream, args=(proc.stdout, stdout_lines, "stdout"), daemon=True
     )
     t_err = threading.Thread(
         target=_stream, args=(proc.stderr, stderr_lines, "stderr"), daemon=True
     )
+    t_hb = threading.Thread(target=_heartbeat, daemon=True)
     t_out.start()
     t_err.start()
+    t_hb.start()
 
     if timeout is not None:
         # Wait for streams to finish within the budget; terminate if exceeded.
@@ -87,6 +125,7 @@ def run_agent(
             sys.stderr.write(msg + "\n")
             if logger is not None:
                 logger.log("runner", msg, level="error")
+            _heartbeat_stop.set()
             try:
                 sb.terminate()
             except Exception:  # noqa: BLE001, S110
@@ -98,6 +137,7 @@ def run_agent(
         t_out.join()
         t_err.join(timeout=_STREAM_JOIN_TIMEOUT)
 
+    _heartbeat_stop.set()
     proc.wait()
 
     stdout = "".join(stdout_lines).rstrip()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -152,3 +152,54 @@ def test_timeout_raises_and_terminates_sandbox():
         run_agent(sb, OpenCodeBackend(), "task", timeout=0.1)
 
     sb.terminate.assert_called_once()
+
+
+# ------------------------------------------------------------------ heartbeat
+
+
+def test_heartbeat_fires_after_silence(capsys, monkeypatch):
+    """Heartbeat line is printed when agent is silent for >= _HEARTBEAT_INTERVAL."""
+    import time
+
+    import agent.runner as runner_mod
+
+    # Speed up the test: very short interval.
+    monkeypatch.setattr(runner_mod, "_HEARTBEAT_INTERVAL", 0.05)
+
+    # Proc yields no output but blocks briefly so the heartbeat has time to fire
+    # before _heartbeat_stop is set.  This simulates an agent that is running
+    # silently (LLM generating) before finishing.
+    def _slow_empty():
+        time.sleep(0.2)
+        return
+        yield  # type: ignore[misc]  # makes this a generator without producing values
+
+    proc = MagicMock()
+    proc.stdout.__iter__ = lambda self: _slow_empty()
+    proc.stderr.__iter__ = lambda self: iter([])
+    proc.returncode = 0
+    proc.wait.return_value = 0
+
+    sb = MagicMock()
+    sb.exec.return_value = proc
+
+    run_agent(sb, OpenCodeBackend(), "task")
+
+    captured = capsys.readouterr()
+    assert "still running" in captured.err
+
+
+def test_heartbeat_does_not_fire_when_output_is_flowing(capsys, monkeypatch):
+    """No heartbeat when output arrives within the interval."""
+    import agent.runner as runner_mod
+
+    monkeypatch.setattr(runner_mod, "_HEARTBEAT_INTERVAL", 60.0)
+
+    proc = _make_proc(stdout="line1\nline2\nline3")
+    sb = MagicMock()
+    sb.exec.return_value = proc
+
+    run_agent(sb, OpenCodeBackend(), "task")
+
+    captured = capsys.readouterr()
+    assert "still running" not in captured.err


### PR DESCRIPTION
Closes #111

## Summary
- Adds a daemon heartbeat thread in `agent/runner.py` that prints `[runner] still running  elapsed=Xs  (no output for Ys)` when the agent has been silent for 30 s
- Resets after each print so it doesn't spam — fires once per 30 s silence window, not every second
- Loop tick = `min(1.0, HEARTBEAT_INTERVAL / 5)` so tests can override the interval without waiting forever
- Stopped cleanly on normal exit and on timeout
- Adds 2 unit tests (`test_heartbeat_fires_after_silence`, `test_heartbeat_does_not_fire_when_output_is_flowing`)

## What it looks like
```
[sandbox] phase=RUNNING   elapsed=1.2s
[sandbox:stderr] [opencode] starting session...
[runner] still running  elapsed=32s  (no output for 30s)
[runner] still running  elapsed=62s  (no output for 30s)
[sandbox:stderr] [opencode] writing auth.py...
```

## Test plan
- [ ] `python3 -m pytest tests/unit/test_runner.py -v` — 15 tests pass
- [ ] `ruff check agent/runner.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)