### PR TITLE
feat(ci): serve endpoint integration tests

### DIFF
--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -1,0 +1,63 @@
+name: Serve endpoint tests
+
+# Validates that the deployed inference endpoint is reachable and serving the
+# expected model.  Must be triggered manually (workflow_dispatch) or via a
+# repository_dispatch event after a successful `modal deploy`.
+#
+# Requires repository secrets:
+#   OPENAI_BASE_URL   — deployed Modal endpoint (no /v1 suffix)
+#   OPENAI_API_KEY    — "modal" for self-hosted endpoints
+#   OPENCODE_MODEL    — model name as served (e.g. qwen2.5-coder-32b)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Inference endpoint base URL (overrides secret)"
+        required: false
+        default: ""
+      model:
+        description: "Model name to verify (overrides secret)"
+        required: false
+        default: ""
+
+jobs:
+  serve-check:
+    name: Serve endpoint reachability
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      OPENAI_BASE_URL: ${{ inputs.base_url || secrets.OPENAI_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'modal' }}
+      OPENCODE_MODEL: ${{ inputs.model || secrets.OPENCODE_MODEL }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Check serve env
+        id: env-check
+        run: |
+          if [ -z "$OPENAI_BASE_URL" ] || [ -z "$OPENCODE_MODEL" ]; then
+            echo "reachable=false" >> $GITHUB_OUTPUT
+            echo "::warning::OPENAI_BASE_URL or OPENCODE_MODEL not set — serve tests skipped"
+          else
+            echo "reachable=true" >> $GITHUB_OUTPUT
+            echo "Testing endpoint: $OPENAI_BASE_URL (model: $OPENCODE_MODEL)"
+          fi
+
+      - name: Run serve endpoint tests
+        if: steps.env-check.outputs.reachable == 'true'
+        run: pytest tests/integration/test_serve_reachable.py -v --tb=short -m serve
+
+      - name: Skip notice
+        if: steps.env-check.outputs.reachable == 'false'
+        run: echo "Serve tests skipped — set OPENAI_BASE_URL and OPENCODE_MODEL as repo secrets"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,5 @@ markers = [
     "unit: pure unit tests, no external services",
     "integration: requires Modal token, uses stub agent",
     "e2e: requires Modal token + real model endpoint, nightly only",
+    "serve: requires a deployed inference endpoint (OPENAI_BASE_URL + OPENCODE_MODEL)",
 ]

--- a/tests/integration/test_serve_reachable.py
+++ b/tests/integration/test_serve_reachable.py
@@ -1,0 +1,124 @@
+"""Integration test: validate the inference endpoint is reachable and well-formed.
+
+Skipped automatically when OPENAI_BASE_URL is not set, so it never blocks CI
+on a machine that hasn't configured a serve endpoint.
+
+Run manually (or in the 'serve' CI job) after deploying modal/serve.py:
+
+    OPENAI_BASE_URL=https://your-org--...modal.run \
+    OPENAI_API_KEY=modal \
+    OPENCODE_MODEL=qwen2.5-coder-32b \
+    pytest tests/integration/test_serve_reachable.py -v -m serve
+
+Checks
+------
+1. GET  /v1/models   — endpoint is up, returns HTTP 200
+2.      model list   — response contains the model name from OPENCODE_MODEL
+3. POST /v1/chat/completions — minimal request completes (non-streaming)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+# Read at collection time — test is skipped entirely when unset.
+_BASE_URL = os.environ.get("OPENAI_BASE_URL", "").rstrip("/")
+_API_KEY = os.environ.get("OPENAI_API_KEY", "modal")
+_MODEL = os.environ.get("OPENCODE_MODEL", "")
+
+pytestmark = pytest.mark.serve
+
+
+def _need_serve_env() -> None:
+    if not _BASE_URL:
+        pytest.skip("OPENAI_BASE_URL not set — skipping serve reachability tests")
+    if not _MODEL:
+        pytest.skip("OPENCODE_MODEL not set — skipping serve reachability tests")
+
+
+def _get(path: str) -> dict:
+    url = f"{_BASE_URL}/v1/{path.lstrip('/')}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {_API_KEY}"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+def _post(path: str, body: dict) -> dict:
+    url = f"{_BASE_URL}/v1/{path.lstrip('/')}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {_API_KEY}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+# ──────────────────────────────────────────────────────────────── tests
+
+
+@pytest.mark.serve
+def test_models_endpoint_returns_200():
+    """GET /v1/models returns HTTP 200 — confirms the server is up."""
+    _need_serve_env()
+    try:
+        data = _get("models")
+    except urllib.error.HTTPError as exc:
+        pytest.fail(f"GET /v1/models returned HTTP {exc.code}: {exc.reason}")
+    except urllib.error.URLError as exc:
+        pytest.fail(f"Cannot reach {_BASE_URL}/v1/models: {exc.reason}")
+
+    assert "data" in data, f"Unexpected /v1/models response shape: {data}"
+
+
+@pytest.mark.serve
+def test_models_endpoint_contains_expected_model():
+    """Model list includes OPENCODE_MODEL — confirms the right weights are loaded."""
+    _need_serve_env()
+    try:
+        data = _get("models")
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        pytest.fail(f"Cannot reach /v1/models: {exc}")
+
+    model_ids = [m.get("id", "") for m in data.get("data", [])]
+    assert any(_MODEL in mid for mid in model_ids), (
+        f"Expected model {_MODEL!r} not found in /v1/models.\n"
+        f"Available models: {model_ids}"
+    )
+
+
+@pytest.mark.serve
+def test_chat_completion_returns_valid_response():
+    """POST /v1/chat/completions with a minimal prompt returns a well-formed response."""
+    _need_serve_env()
+    try:
+        response = _post(
+            "chat/completions",
+            {
+                "model": _MODEL,
+                "messages": [{"role": "user", "content": "Reply with just the word PONG."}],
+                "max_tokens": 16,
+                "temperature": 0,
+            },
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace") if hasattr(exc, "read") else ""
+        pytest.fail(f"POST /v1/chat/completions returned HTTP {exc.code}: {body[:300]}")
+    except urllib.error.URLError as exc:
+        pytest.fail(f"Cannot reach /v1/chat/completions: {exc.reason}")
+
+    assert "choices" in response, f"Missing 'choices' in response: {response}"
+    assert len(response["choices"]) > 0, "Empty choices list"
+    choice = response["choices"][0]
+    assert "message" in choice, f"Missing 'message' in choice: {choice}"
+    content = choice["message"].get("content", "")
+    assert content, "Empty content in response message"


### PR DESCRIPTION
Closes #68

## Summary
- Adds `tests/integration/test_serve_reachable.py` with 3 checks:
  1. `GET /v1/models` returns HTTP 200 — confirms server is up
  2. Model list contains `OPENCODE_MODEL` — confirms right weights are loaded
  3. `POST /v1/chat/completions` with minimal prompt — confirms API surface works end-to-end
- Tests skip cleanly when `OPENAI_BASE_URL` or `OPENCODE_MODEL` are not set (never blocks CI)
- Adds `.github/workflows/serve.yml` — manual trigger (`workflow_dispatch`) with optional `base_url` / `model` input overrides; falls back to repo secrets
- Registers `serve` pytest marker in `pyproject.toml`

## Test plan
- [ ] `pytest tests/integration/test_serve_reachable.py -v` — all 3 skip when env unset
- [ ] `ruff check tests/integration/test_serve_reachable.py` — passes
- [ ] Manual: set `OPENAI_BASE_URL` + `OPENCODE_MODEL` and run — all 3 pass against live endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)