### PR TITLE
docs: update all docs for Phase 4 completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,17 +179,29 @@ vars each backend needs, in the exact format it expects:
 
 ## Model profiles
 
-Three profiles in `modal/serve.py`, selected by `SERVE_PROFILE`:
+Two profiles in `modal/serve.py`, selected by `SERVE_PROFILE`:
 
-| Profile | Engine | Model | GPU | Context | Best for |
-|---|---|---|---|---|---|
-| `test` (default) | vLLM | Qwen2.5-Coder 32B | A100 80GB | 32k | Development, CI |
-| `prod` | vLLM | Qwen3-Coder 80B (default) | 2× A100 80GB | 128k | Production PRs |
-| `prod` + `SERVE_MODEL=minimax-m2.5` | vLLM | MiniMax M2.5 | 8× A100 80GB | 1M | Best quality / SWE-bench |
-| `experiment` | SGLang | Qwen2.5-Coder 32B | A100 80GB | 32k | SGLang evaluation |
+- **`prod`** (default) — vLLM engine. Model selected via `SERVE_MODEL`.
+- **`experiment`** — SGLang engine, Qwen2.5-Coder 7B, separate Modal app (never disturbs prod).
 
-`prod` selects the model via `SERVE_MODEL` (default `qwen3-coder`). `experiment` deploys to a
-separate Modal app (`agent-container-serve-experiment`) so the vLLM endpoint is never disturbed.
+### Model registry (`prod`)
+
+| `SERVE_MODEL` | Model | GPU | Context | Best for |
+|---|---|---|---|---|
+| `qwen2.5-coder-32b` (default) | Qwen2.5-Coder 32B | A100 80GB | 32k | Reliable tool use, development |
+| `qwen3-coder` | Qwen3-Coder 80B | 2× A100 80GB | 128k | Production PRs |
+| `qwen3-8b` | Qwen3 8B | A10G | 32k | Fast, cheap, simple tasks |
+| `qwen3-30b` | Qwen3 30B-A3B (MoE) | A100 40GB | 32k | Efficient MoE |
+| `gemma4-12b` | Gemma 4 12B | A10G | 32k | Google, fast |
+| `gemma4-27b` | Gemma 4 27B | A100 40GB | 32k | Google, quality |
+| `minimax-m2.5` | MiniMax M2.5 (MoE) | 8× A100 80GB | 1M | SWE-bench grade |
+
+```bash
+modal deploy modal/serve.py                        # prod, qwen2.5-coder-32b (default)
+SERVE_MODEL=qwen3-8b    modal deploy modal/serve.py # prod, Qwen3 8B
+SERVE_MODEL=gemma4-27b  modal deploy modal/serve.py # prod, Gemma 4 27B
+SERVE_PROFILE=experiment modal deploy modal/serve.py # SGLang experiment
+```
 
 Scale-to-zero is on by default — you only pay while runs are active. Model weights are cached in a
 Modal Volume so cold starts after the first don't re-download weights.
@@ -309,9 +321,11 @@ make test-integration   # real Modal sandbox, stub agent (no LLM needed)
 make test-e2e           # real Modal sandbox + real model
 ```
 
-271 unit tests covering config, spec, sandbox, git ops, runner, tester, proxy, log store, dashboard, MCP, and CLI. All run in-process with no external services.
+282 unit tests covering config, spec, sandbox, git ops, runner, tester, proxy, log store, dashboard, MCP, CLI, and aider runner. All run in-process with no external services.
 
 The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the complete Responses API → Chat Completions translation including the full SSE event sequence and token accumulation logic.
+
+Serve endpoint integration tests (`tests/integration/test_serve_reachable.py`) validate the deployed inference endpoint against a live `OPENAI_BASE_URL` — skipped automatically when not configured.
 
 ---
 
@@ -322,6 +336,7 @@ The proxy test suite (`tests/unit/test_responses_proxy.py`) covers the complete 
 | Phase 1 | vLLM + aider: direct Chat Completions, end-to-end PR | ✅ |
 | Phase 2 | Clean opencode proxy: pure Responses API ↔ Chat Completions adapter | ✅ |
 | Phase 3 | SGLang validation: deploy alongside vLLM, confirm tool calling end-to-end | ✅ |
+| Phase 4 | Observability + model expansion: token tracking, heartbeat, model registry | ✅ |
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -142,8 +142,8 @@ calling reliably and to reason across multiple turns.
 
 ### When to use aider
 
-- **Default choice.** Works with the `test` profile (Qwen2.5-Coder 32B on A100 80GB) — smallest,
-  cheapest GPU.
+- **Default choice.** Works with the default model (`qwen2.5-coder-32b` on A100 80GB) — reliable
+  tool use, reasonable cost.
 - The task is well-specified: "add a `sum_to_n` function to `mathlib.py`", "fix the off-by-one
   in `paginate()`". The model knows exactly what to write.
 - You want the fastest turnaround — one model call, one diff, done.
@@ -170,8 +170,8 @@ calling reliably and to reason across multiple turns.
 | Model calls per task | 1–2 | 5–20+ |
 | Requires tool calling | No | Yes |
 | Can run tests and iterate | No | Yes |
-| Works on `test` profile (32B) | Yes | Possible but weaker |
-| Recommended GPU profile | `test` or higher | `prod` or `minimax` |
+| Works with default model (32B) | Yes | Possible but weaker |
+| Recommended model | `qwen2.5-coder-32b` or higher | `qwen3-coder` or `minimax-m2.5` |
 | Cold start sensitivity | Low (fewer calls) | Higher (more round-trips) |
 | Best task type | Targeted, well-specified edits | Debugging, multi-file, self-verifying |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ The `sglang` profile deploys to a **separate Modal app** (`agent-container-serve
 both inference servers can run simultaneously without interfering:
 
 ```
-agent-container-serve            → vLLM  (SERVE_PROFILE=test or prod)
+agent-container-serve            → vLLM  (SERVE_PROFILE=prod, default)
 agent-container-serve-experiment → SGLang (SERVE_PROFILE=experiment, hermes parser)
 ```
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -55,8 +55,10 @@ logs as they arrive. Rows remain in the list after completion — collapse them 
 
 ### Tokens tab
 
-Per-run token consumption for all completed runs that have token data (opencode via the Responses
-API proxy; other backends emit no usage data unless they log the `[runner] token_usage:` line).
+Per-run token consumption for all completed runs that have token data. Both `aider` and `opencode`
+emit token usage — `aider` by parsing its `Tokens: X sent, Y received.` stderr lines; `opencode`
+via the Responses API proxy's `usage` accumulation. Both emit the same `[runner] token_usage:`
+line that the sandbox intercepts and persists to SQLite.
 
 | Column | Description |
 |---|---|
@@ -106,14 +108,18 @@ load comes from SQLite, so CLI runs appear alongside dashboard runs automaticall
 The serve panel in the sidebar lets you deploy or redeploy the model server without touching
 the terminal.
 
-**Profile options:**
+**Model options (all `prod` / vLLM unless noted):**
 
-| Option | Profile + model |
+| Option | `SERVE_MODEL` |
 |---|---|
-| test — Qwen2.5-Coder 32B (A100 80GB) | `SERVE_PROFILE=test` |
-| prod — Qwen3-Coder 80B (2×A100) | `SERVE_PROFILE=prod` |
-| prod — MiniMax M2.5 (8×A100) | `SERVE_PROFILE=prod SERVE_MODEL=minimax-m2.5` |
-| experiment — SGLang (A10G) | `SERVE_PROFILE=experiment` |
+| Qwen2.5-Coder 32B · A100 80GB **(default)** | *(unset)* |
+| Qwen3-Coder 80B · 2×A100 80GB | `qwen3-coder` |
+| Qwen3 8B · A10G | `qwen3-8b` |
+| Qwen3 30B-A3B · A100 40GB | `qwen3-30b` |
+| Gemma 4 12B · A10G | `gemma4-12b` |
+| Gemma 4 27B · A100 40GB | `gemma4-27b` |
+| MiniMax M2.5 · 8×A100 80GB | `minimax-m2.5` |
+| SGLang experiment · A10G | `SERVE_PROFILE=experiment` |
 
 The status badge polls `GET /api/serve/status` every 30 seconds and shows the current Modal
 app state. Clicking **Deploy** calls `POST /api/serve/deploy` and triggers a background

--- a/docs/models.md
+++ b/docs/models.md
@@ -16,37 +16,47 @@ OPENCODE_MODEL=qwen2.5-coder  # must match SERVED_MODEL_NAME in modal/serve.py
 
 ---
 
-## GPU profiles
+## Profiles and model registry
 
-Three profiles are built into `modal/serve.py`, selected by `SERVE_PROFILE`:
+Two profiles in `modal/serve.py`, selected by `SERVE_PROFILE`:
 
-| Profile | Engine | Model | GPU | Context | Deploy command |
-|---------|--------|-------|-----|---------|----------------|
-| `test` (default) | vLLM | Qwen2.5-Coder-32B | A100 80GB | 32k | `modal deploy modal/serve.py` |
-| `prod` | vLLM | Qwen3-Coder-80B (default) | 2× A100 80GB | 128k | `SERVE_PROFILE=prod modal deploy modal/serve.py` |
-| `prod` + `SERVE_MODEL=minimax-m2.5` | vLLM | MiniMax-M2.5 | 8× A100 80GB | 1M | `SERVE_PROFILE=prod SERVE_MODEL=minimax-m2.5 modal deploy modal/serve.py` |
-| `experiment` | SGLang | Qwen2.5-Coder-32B | A10G | 32k | `SERVE_PROFILE=experiment modal deploy modal/serve.py` |
+- **`prod`** (default) — vLLM engine, model selected via `SERVE_MODEL`.
+- **`experiment`** — SGLang engine, Qwen2.5-Coder 7B, deploys to a **separate** Modal app so the prod endpoint is never disturbed.
 
-**Start with `test`** — cheap, fast iteration. Promote to `prod` for production-grade output
-quality. Use `SERVE_MODEL=minimax-m2.5` inside `prod` for maximum quality (SWE-bench grade).
-Use `experiment` to run SGLang instead of vLLM — see the comparison table below.
+### prod model registry
 
-`prod` model selection is driven by `SERVE_MODEL`. Add new models to the `_PROD_MODELS` dict
-in `modal/serve.py` without touching the profile structure.
+All prod models use vLLM. Select with `SERVE_MODEL`:
 
-`experiment` deploys to a **separate** Modal app (`agent-container-serve-experiment`) so the
-vLLM endpoint is never disturbed — both can run simultaneously.
+| `SERVE_MODEL` | Model | GPU | Context | Deploy command |
+|---|---|---|---|---|
+| `qwen2.5-coder-32b` **(default)** | Qwen2.5-Coder 32B | A100 80GB | 32k | `modal deploy modal/serve.py` |
+| `qwen3-coder` | Qwen3-Coder 80B | 2× A100 80GB | 128k | `SERVE_MODEL=qwen3-coder modal deploy modal/serve.py` |
+| `qwen3-8b` | Qwen3 8B | A10G | 32k | `SERVE_MODEL=qwen3-8b modal deploy modal/serve.py` |
+| `qwen3-30b` | Qwen3 30B-A3B (MoE) | A100 40GB | 32k | `SERVE_MODEL=qwen3-30b modal deploy modal/serve.py` |
+| `gemma4-12b` | Gemma 4 12B | A10G | 32k | `SERVE_MODEL=gemma4-12b modal deploy modal/serve.py` |
+| `gemma4-27b` | Gemma 4 27B | A100 40GB | 32k | `SERVE_MODEL=gemma4-27b modal deploy modal/serve.py` |
+| `minimax-m2.5` | MiniMax M2.5 (MoE) | 8× A100 80GB | 1M | `SERVE_MODEL=minimax-m2.5 modal deploy modal/serve.py` |
+
+**Start with the default (`qwen2.5-coder-32b`)** — proven tool use, fast iteration.
+Switch to `qwen3-8b` or `gemma4-12b` for cheaper/faster runs on simple tasks.
+Use `qwen3-coder` or `minimax-m2.5` for production-grade output quality.
+
+Add new models to the `_PROD_MODELS` dict in `modal/serve.py` — GPU, context, and tool-call parser are declared per-model.
 
 ### Model names
 
-Set `OPENCODE_MODEL` to match `SERVED_MODEL_NAME` in `modal/serve.py`:
+Set `OPENCODE_MODEL` to match `served_name` in `modal/serve.py`:
 
-| Profile | `OPENCODE_MODEL` |
-|---------|-----------------|
-| `test` | `qwen2.5-coder` |
-| `prod` (default model) | `qwen3-coder` |
-| `prod` + `SERVE_MODEL=minimax-m2.5` | `minimax-m2.5` |
-| `experiment` | `qwen2.5-coder` |
+| `SERVE_MODEL` | `OPENCODE_MODEL` |
+|---|---|
+| `qwen2.5-coder-32b` (default) | `qwen2.5-coder-32b` |
+| `qwen3-coder` | `qwen3-coder` |
+| `qwen3-8b` | `qwen3-8b` |
+| `qwen3-30b` | `qwen3-30b` |
+| `gemma4-12b` | `gemma4-12b` |
+| `gemma4-27b` | `gemma4-27b` |
+| `minimax-m2.5` | `minimax-m2.5` |
+| `experiment` profile | `qwen2.5-coder` |
 
 ---
 
@@ -82,7 +92,7 @@ profiles and handles:
 
 | | vLLM | SGLang |
 |--|------|--------|
-| Status | Default — `test` and `prod` profiles | Validated alternative (`experiment` profile) |
+| Status | Default — `prod` profile | Validated alternative (`experiment` profile) |
 | Tool calling | Stable — `hermes` parser, works out of the box | Works with `hermes` parser; `qwen`/`qwen25` hangs |
 | Base image | `debian_slim` — no CUDA toolkit needed | `nvidia/cuda:12.4.1-devel-ubuntu22.04` + `libnuma1` required |
 | JIT compilation | None at startup | Compiles rope/attention kernels via TVM at model-load time |
@@ -153,15 +163,17 @@ OPENAI_BASE_URL=https://your-org--agent-container-serve-experiment-serve.modal.r
 Modal scales the model server to zero after `scaledown_window` seconds of inactivity.
 You pay only for active inference time.
 
-| Profile | Cold start |
-|---------|-----------|
-| `test` | ~1–2 min |
-| `prod` (qwen3-coder) | ~3–5 min |
-| `prod` + `SERVE_MODEL=minimax-m2.5` | ~8–12 min |
-| `experiment` | ~2–3 min (JIT compile adds ~1 min) |
+| `SERVE_MODEL` | Cold start |
+|---|---|
+| `qwen2.5-coder-32b` (default) | ~1–2 min |
+| `qwen3-8b` / `gemma4-12b` | ~1–2 min (A10G) |
+| `qwen3-30b` / `gemma4-27b` | ~2–3 min (A100 40GB) |
+| `qwen3-coder` | ~3–5 min (2× A100 80GB) |
+| `minimax-m2.5` | ~8–12 min (8× A100 80GB) |
+| `experiment` (SGLang) | ~2–3 min (JIT compile adds ~1 min) |
 
 Model weights are stored in a Modal Volume (`agent-container-models`) and are not
 re-downloaded on cold start after the first deploy.
 
-The agent sandbox waits for the model to be ready before starting (preflight probe with
-configurable timeout via `SERVE_COLDSTART_BUDGET`).
+The agent sandbox waits for the model to be ready before starting (WARMING phase polls
+`GET /v1/models` with a configurable budget via `timeout_coldstart`).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,7 +41,8 @@ Proxy correctness, per-phase timeouts, CI guards, test coverage, token tracking.
 - [#67](https://github.com/dvdthecoder/agent-container/issues/67) 24 unit tests for Responses API proxy — `_convert_tools`, `_convert_input_items`, `_translate_chat_response`, `_stream_chat_to_responses`, full SSE event sequence
 - CI guard: `scripts/check_container_imports.py` blocks dev-only packages (`pytest`, `ruff`, etc.) from being imported in `modal/` or `agent/` at commit time
 - opencode pinned to `1.14.31` — deliberate upgrade path with proxy compatibility check
-- [#130](https://github.com/dvdthecoder/agent-container/issues/130) Token usage tab: proxy accumulates `usage` from every Chat Completions turn; persisted to SQLite; dashboard **Tokens** tab shows per-run prompt/completion/total tokens with live cost estimate and backend/date filters; 271 unit tests total
+- [#130](https://github.com/dvdthecoder/agent-container/issues/130) Token usage tab: proxy accumulates `usage` from every Chat Completions turn; persisted to SQLite; dashboard **Tokens** tab shows per-run prompt/completion/total tokens with live cost estimate and backend/date filters
+- [#132](https://github.com/dvdthecoder/agent-container/issues/132) aider token capture: parses `Tokens: X sent, Y received.` from aider stderr, emits same `[runner] token_usage:` line as opencode — both backends now populate the Tokens tab
 
 ### Phase 3 — SGLang validation (done)
 SGLang deployed as a separate Modal app (`agent-container-serve-sglang`); tool calling confirmed working with `hermes` parser.
@@ -53,22 +54,30 @@ SGLang deployed as a separate Modal app (`agent-container-serve-sglang`); tool c
 - Fix tool-call parser — `qwen`/`qwen25` hangs on first tool-schema request; `hermes` resolves in 3s
 - `make example BACKEND=opencode` against SGLang endpoint: tool call with 10 tools → ok (3.0s), PR opened
 
+### Phase 4 — Model expansion + richer observability (done)
+Broader model menu, live feedback during runs, serve endpoint validation.
+
+- [#113](https://github.com/dvdthecoder/agent-container/issues/113) Expanded prod model registry: `qwen3-8b`, `qwen3-30b`, `gemma4-12b`, `gemma4-27b` added alongside `qwen3-coder` and `minimax-m2.5`; `tool_call_parser` and `startup_timeout` are now per-model
+- Profile/model separation: `test` profile dissolved into `prod` with `qwen2.5-coder-32b` as the default `SERVE_MODEL`; only two profiles remain (`prod` vLLM, `experiment` SGLang)
+- [#111](https://github.com/dvdthecoder/agent-container/issues/111) Heartbeat thread in `agent/runner.py` — prints `[runner] still running elapsed=Xs` every 30 s when the agent is silent; terminal never goes dark during a long RUNNING phase
+- [#68](https://github.com/dvdthecoder/agent-container/issues/68) Serve endpoint integration tests — `tests/integration/test_serve_reachable.py` validates `GET /v1/models` (HTTP 200, model name present) and `POST /v1/chat/completions` (well-formed response); `.github/workflows/serve.yml` triggers manually after deploy
+- 282 unit tests total (up from 271); new `serve` pytest marker
+
 ---
 
 ## Planned
 
-### Phase 4 — Model expansion + richer observability
-Broaden the model menu and deepen run observability.
+### Phase 5 — Docs + quality tooling
+Fill documentation gaps and add model comparison data.
 
 | Issue | Task |
 |---|---|
-| [#113](https://github.com/dvdthecoder/agent-container/issues/113) | Add Qwen3-Coder and Gemma 4 model profiles to `serve.py` (vLLM) |
-| [#114](https://github.com/dvdthecoder/agent-container/issues/114) | Docs: cost and quality comparison — self-hosted LLMs vs Claude API |
-| [#115](https://github.com/dvdthecoder/agent-container/issues/115) | Docs: step-by-step guide for adding a new model profile |
+| [#114](https://github.com/dvdthecoder/agent-container/issues/114) | Cost and quality comparison — self-hosted LLMs vs Claude API; populate Tokens tab with baseline runs |
+| [#115](https://github.com/dvdthecoder/agent-container/issues/115) | Step-by-step guide for adding a new model profile |
+| [#71](https://github.com/dvdthecoder/agent-container/issues/71) | `docs/lessons-learned.md` — hard problems, gotchas, team scaling guide |
 | [#112](https://github.com/dvdthecoder/agent-container/issues/112) | Install opencode-monitor in sandbox — structured per-tool-call events in logs |
-| [#111](https://github.com/dvdthecoder/agent-container/issues/111) | Stream real-time agent progress in CLI during RUNNING phase |
 
-### Phase 5 — Production hardening
+### Phase 6 — Production hardening
 Close the gap between the current implementation and a fully team-deployed system.
 
 | Issue | Task |
@@ -76,7 +85,7 @@ Close the gap between the current implementation and a fully team-deployed syste
 | [#107](https://github.com/dvdthecoder/agent-container/issues/107) | Warm sandboxes via Modal snapshot API — eliminate cold-start clone+install latency |
 | [#108](https://github.com/dvdthecoder/agent-container/issues/108) | Deeper verification loop — Sentry errors, metrics, visual screenshots for frontend |
 
-### Phase 6 — Team and integrations
+### Phase 7 — Team and integrations
 Broader entry points and collaboration features.
 
 | Issue | Task |

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -206,7 +206,7 @@ The sandbox cost is small relative to the model cost.
 
 ### Reducing cost
 
-- Use `SERVE_PROFILE=test` (32B test model) for simple, well-specified tasks — 8× cheaper
+- Use `SERVE_MODEL=qwen3-8b` or `qwen2.5-coder-32b` (default) for simple, well-specified tasks — 8× cheaper than 80B models
 - Use `--backend aider` for targeted edits — fewer model calls than opencode
 - Use `--no-pr` during iteration to skip git push/PR overhead
 - Set `--timeout` appropriately — a stuck run burns GPU time


### PR DESCRIPTION
## Summary
Brings all documentation up to date with everything merged this week.

**README**
- Model profiles section rewritten: `test` profile removed, full prod registry table (7 models with GPU/context)
- Test count 271 → 282; serve integration test mentioned
- Phase 4 added to build phases table

**docs/models.md**
- `test` profile removed; `prod` is default (`qwen2.5-coder-32b`)
- Full model registry table with deploy commands per model
- Cold start table keyed by `SERVE_MODEL`

**docs/dashboard.md**
- Tokens tab: explicitly states both `aider` and `opencode` now emit token usage
- Serve panel: replaced test profile with full 8-option model list

**docs/roadmap.md**
- Phase 2.5: aider token capture (#132) added
- Phase 4 marked **done**: model registry, heartbeat, serve integration tests, profile/model separation
- Planned phases renumbered 5/6/7; #71 lessons-learned added to Phase 5

**docs/architecture.md, docs/agents.md, docs/teams.md**
- All `SERVE_PROFILE=test` references removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)