### PR TITLE
fix(agent): token capture + proxy index error from test-analysis run

### DIFF
--- a/agent/aider_runner.py
+++ b/agent/aider_runner.py
@@ -73,11 +73,23 @@ cmd = [
 # ---------------------------------------------------------------------------
 # Token tracking
 # ---------------------------------------------------------------------------
-# aider prints one line per model call to stderr:
+# aider prints one line per model call to stderr in one of two formats:
 #   Tokens: 2,841 sent, 381 received. Cost: $0.00 message, $0.00 session.
+#   Tokens: 2.7k sent, 109 received. Cost: $0.00 message, $0.00 session.
 # We accumulate across all turns and emit a summary line that sandbox.py
 # already knows how to parse: [runner] token_usage: prompt=X completion=Y total=Z
-_TOKEN_RE = re.compile(r"Tokens:\s+([\d,]+)\s+sent,\s+([\d,]+)\s+received")
+_TOKEN_RE = re.compile(r"Tokens:\s+([\d,.]+[kKmM]?)\s+sent,\s+([\d,.]+[kKmM]?)\s+received")
+
+
+def _parse_tok(s: str) -> int:
+    """Parse aider's token abbreviations: '2.7k' → 2700, '1.2M' → 1200000, '2,841' → 2841."""
+    s = s.replace(",", "")
+    if s[-1] in ("k", "K"):
+        return int(float(s[:-1]) * 1_000)
+    if s[-1] in ("m", "M"):
+        return int(float(s[:-1]) * 1_000_000)
+    return int(float(s))
+
 
 _prompt_tokens = 0
 _completion_tokens = 0
@@ -93,8 +105,8 @@ def _stream(source, dest, is_stderr: bool) -> None:
         if is_stderr:
             m = _TOKEN_RE.search(line)
             if m:
-                _prompt_tokens += int(m.group(1).replace(",", ""))
-                _completion_tokens += int(m.group(2).replace(",", ""))
+                _prompt_tokens += _parse_tok(m.group(1))
+                _completion_tokens += _parse_tok(m.group(2))
 
 
 # ---------------------------------------------------------------------------

--- a/agent/opencode_runner.py
+++ b/agent/opencode_runner.py
@@ -311,7 +311,7 @@ class _ProxyHandler(http.server.BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             return raw
 
-        message = chat.get("choices", [{}])[0].get("message", {})
+        message = (chat.get("choices") or [{}])[0].get("message", {})
         text = message.get("content") or ""
         native_tool_calls = message.get("tool_calls") or []
 
@@ -390,7 +390,8 @@ class _ProxyHandler(http.server.BaseHTTPRequestHandler):
             if chunk.get("usage"):
                 _accumulate_tokens(chunk["usage"])
 
-            delta = chunk.get("choices", [{}])[0].get("delta", {})
+            # choices may be [] on usage-only chunks — use `or` so empty list falls back.
+            delta = (chunk.get("choices") or [{}])[0].get("delta", {})
             text_delta = delta.get("content") or ""
             if text_delta:
                 full_text.append(text_delta)

--- a/tests/unit/test_aider_runner.py
+++ b/tests/unit/test_aider_runner.py
@@ -75,6 +75,13 @@ class TestTokenRegex:
         assert m.group(1) == "2,841"
         assert m.group(2) == "381"
 
+    def test_matches_abbreviated_k_format(self):
+        line = "Tokens: 2.7k sent, 109 received. Cost: $0.00 message, $0.00 session."
+        m = self.mod._TOKEN_RE.search(line)
+        assert m is not None
+        assert m.group(1) == "2.7k"
+        assert m.group(2) == "109"
+
     def test_matches_small_numbers(self):
         line = "Tokens: 100 sent, 50 received."
         m = self.mod._TOKEN_RE.search(line)
@@ -89,6 +96,26 @@ class TestTokenRegex:
     def test_does_not_match_partial_line(self):
         line = "Tokens: 100 sent."
         assert self.mod._TOKEN_RE.search(line) is None
+
+
+class TestParseTok:
+    def setup_method(self):
+        self.mod = _load_aider_runner()
+
+    def test_plain_integer(self):
+        assert self.mod._parse_tok("381") == 381
+
+    def test_comma_separated(self):
+        assert self.mod._parse_tok("2,841") == 2841
+
+    def test_k_suffix(self):
+        assert self.mod._parse_tok("2.7k") == 2700
+
+    def test_K_suffix(self):
+        assert self.mod._parse_tok("2.7K") == 2700
+
+    def test_m_suffix(self):
+        assert self.mod._parse_tok("1.2M") == 1_200_000
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +143,14 @@ class TestStream:
         )
         assert self.mod._prompt_tokens == 1000
         assert self.mod._completion_tokens == 200
+
+    def test_stderr_accumulates_abbreviated_tokens(self):
+        self._run_stream(
+            ["Tokens: 2.7k sent, 109 received. Cost: $0.00 message, $0.00 session."],
+            is_stderr=True,
+        )
+        assert self.mod._prompt_tokens == 2700
+        assert self.mod._completion_tokens == 109
 
     def test_stderr_accumulates_across_multiple_lines(self):
         lines = [


### PR DESCRIPTION
## Summary

Two bugs found by running `make test-analysis` for the first time:

**Bug 1 — aider token regex (tokens logged as 0)**
- Newer aider versions print `Tokens: 2.7k sent, 109 received.` (abbreviated)
- Old regex `[\d,]+` only matched plain integers like `2,841`
- Added `_parse_tok()` helper: handles plain int, comma-sep, `k`/`K`, `m`/`M` suffixes
- Updated `_TOKEN_RE` pattern to `[\d,.]+[kKmM]?`

**Bug 2 — opencode proxy `list index out of range`**
- vLLM sends a usage-only SSE chunk: `{"choices": [], "usage": {...}}`
- `chunk.get("choices", [{}])` returns `[]` (the actual value, not the default) for empty list
- Then `[][0]` → `IndexError` → 502 back to opencode → empty diff → run fails
- Fixed streaming path (`_stream_chat_to_responses`) and non-streaming path (`_translate_chat_response`) with `(chunk.get("choices") or [{}])[0]`

## Test plan

- [ ] `make test` — 289 unit tests pass
- [ ] `make test-analysis BACKENDS=aider` — tokens column now populated
- [ ] `make test-analysis BACKENDS=opencode` — no more proxy 502s

Closes #132 (token capture complete), relates to #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)