### PR TITLE
fix(opencode): emit token_usage on failed/timed-out runs

### DIFF
--- a/agent/opencode_runner.py
+++ b/agent/opencode_runner.py
@@ -805,14 +805,8 @@ def main() -> int:
         file=sys.stderr,
     )
 
-    if stop_reason != "session_completed":
-        print(f"[runner] unexpected stop: {stop_reason or 'timeout'}", file=sys.stderr)
-        client.terminate()
-        return 1
-
-    client.terminate()
-
-    # Emit token usage so the host process can persist it to the run log.
+    # Always emit token usage — sandbox.py reads this line to persist tokens to SQLite.
+    # Emit before any early return so failed/timed-out runs still record what was spent.
     with _token_lock:
         p = _token_counts["prompt"]
         c = _token_counts["completion"]
@@ -822,6 +816,12 @@ def main() -> int:
         flush=True,
     )
 
+    if stop_reason != "session_completed":
+        print(f"[runner] unexpected stop: {stop_reason or 'timeout'}", file=sys.stderr)
+        client.terminate()
+        return 1
+
+    client.terminate()
     return 0
 
 


### PR DESCRIPTION
## Summary

The `[runner] token_usage:` line in `opencode_runner.py` was only printed on
the happy path (`stop_reason == "session_completed"`). Any run that timed out,
hit a proxy error, or produced an empty diff returned early without emitting
it — so `sandbox.py`'s regex never fired, `logger.set_token_usage()` was never
called, and those runs had `total_tokens=NULL` in SQLite.

Fix: move the emit before the `stop_reason` check so it always fires regardless
of outcome. Failed runs still cost tokens; we should record them.

## Test plan

- [ ] `make test` — 289 unit tests pass
- [ ] Re-run `make test-analysis BACKENDS=opencode` — token columns now populated even when run fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)