### PR TITLE
fix(analysis): create PRs by default in make test-analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-serve:
 BACKENDS     ?= aider,opencode
 RUNS         ?= 1
 COST_PER_1M  ?= 1.00
-NO_PR        ?= 1
+NO_PR        ?= 0
 
 test-analysis:
 	ANALYSIS_BACKENDS=$(BACKENDS) \

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ make test               # unit tests — no external services, always free
 make test-integration   # real Modal sandbox, stub agent (no LLM needed)
 make test-e2e           # real Modal sandbox + real model
 make test-serve         # inference endpoint reachability (requires OPENAI_BASE_URL + OPENCODE_MODEL)
-make test-analysis      # token/cost/quality analysis across backends (fires real runs, prints Markdown table)
+make test-analysis      # token/cost/quality analysis across backends (fires real runs, creates PRs, prints Markdown table)
 ```
 
 `test-analysis` accepts optional overrides:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,7 @@ make test               # unit tests — no external services, always fast
 make test-integration   # real Modal sandbox, stub agent (no model needed)
 make test-e2e           # real Modal sandbox + real model (nightly only)
 make test-serve         # inference endpoint reachability (requires OPENAI_BASE_URL + OPENCODE_MODEL)
-make test-analysis      # token/cost/quality analysis — fires real runs, prints Markdown table
+make test-analysis      # token/cost/quality analysis — fires real runs, creates PRs, prints Markdown table
 ```
 
 `test-analysis` accepts optional overrides:


### PR DESCRIPTION
## Summary

`NO_PR` defaulted to `1` in the Makefile, so `make test-analysis` always printed `Create PR: False` and skipped the entire push + PR step. This means the most brittle part of the pipeline (GITHUB_TOKEN, git push, GitHub API) was never exercised by the analysis run.

Changed default to `NO_PR ?= 0`. Pass `NO_PR=1` explicitly to skip when iterating quickly without wanting to create fixture PRs.

## Test plan

- [ ] `make test-analysis` output now shows `Create PR: True`
- [ ] Runs produce PRs on the fixture repo
- [ ] `make test-analysis NO_PR=1` still skips PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)