### PR TITLE
fix(sandbox): upload runner scripts fresh per-run instead of baking into image

### DIFF
--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -60,8 +60,10 @@ _BASE_IMAGE = (
         # pinned — update deliberately after verifying proxy compatibility
         "npm install -g opencode-ai@1.14.31",
     )
-    .add_local_file("agent/aider_runner.py", "/aider_runner.py", copy=True)
-    .add_local_file("agent/opencode_runner.py", "/opencode_runner.py", copy=True)
+    # copy=False (default): uploaded fresh from local disk on every sandbox start.
+    # This ensures code changes are picked up immediately without stale image caches.
+    .add_local_file("agent/aider_runner.py", "/aider_runner.py")
+    .add_local_file("agent/opencode_runner.py", "/opencode_runner.py")
 )
 
 


### PR DESCRIPTION
## Summary

`add_local_file(..., copy=True)` bakes files into the Modal image layer at build time. Modal caches that layer aggressively — after merging fixes to `aider_runner.py` and `opencode_runner.py`, containers kept running old code for multiple runs because the image cache wasn't invalidated.

**Result:** aider token regex fix (k-suffix parsing) and opencode token emit fix both went undetected in production — every run after the fixes still showed 0 or NULL tokens.

**Fix:** Remove `copy=True` (revert to Modal default `copy=False`). The runner scripts are now uploaded fresh from local disk on every sandbox start. The expensive layers (pip_install, nodejs, opencode install) remain fully cached — only the two tiny Python scripts get re-uploaded per run, adding negligible startup time.

## Test plan

- [ ] `make test` passes
- [ ] `make test-analysis` — aider now captures `2.7k` → 2700 tokens, opencode emits tokens on all exit paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)