### PR TITLE
fix(aider): scan both stdout and stderr for token lines

### DIFF
--- a/agent/aider_runner.py
+++ b/agent/aider_runner.py
@@ -73,7 +73,8 @@ cmd = [
 # ---------------------------------------------------------------------------
 # Token tracking
 # ---------------------------------------------------------------------------
-# aider prints one line per model call to stderr in one of two formats:
+# aider prints one line per model call in one of two formats (stdout or stderr
+# depending on version — we scan both):
 #   Tokens: 2,841 sent, 381 received. Cost: $0.00 message, $0.00 session.
 #   Tokens: 2.7k sent, 109 received. Cost: $0.00 message, $0.00 session.
 # We accumulate across all turns and emit a summary line that sandbox.py
@@ -95,18 +96,19 @@ _prompt_tokens = 0
 _completion_tokens = 0
 
 
-def _stream(source, dest, is_stderr: bool) -> None:
-    """Forward *source* lines to *dest*, parsing token lines when on stderr."""
+def _stream(source, dest, is_stderr: bool) -> None:  # noqa: ARG001
+    """Forward *source* lines to *dest*, parsing token lines from either stream."""
     global _prompt_tokens, _completion_tokens  # noqa: PLW0603
     for raw in source:
         line = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
         dest.write(line)
         dest.flush()
-        if is_stderr:
-            m = _TOKEN_RE.search(line)
-            if m:
-                _prompt_tokens += _parse_tok(m.group(1))
-                _completion_tokens += _parse_tok(m.group(2))
+        # Scan both stdout and stderr — aider version determines which stream
+        # receives the "Tokens: X sent, Y received." summary line.
+        m = _TOKEN_RE.search(line)
+        if m:
+            _prompt_tokens += _parse_tok(m.group(1))
+            _completion_tokens += _parse_tok(m.group(2))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_aider_runner.py
+++ b/tests/unit/test_aider_runner.py
@@ -162,13 +162,14 @@ class TestStream:
         assert self.mod._prompt_tokens == 800
         assert self.mod._completion_tokens == 180
 
-    def test_stdout_does_not_accumulate_tokens(self):
+    def test_stdout_also_accumulates_tokens(self):
+        # aider version determines which stream gets the Tokens line — scan both.
         self._run_stream(
             ["Tokens: 1,000 sent, 200 received. Cost: $0.00 message, $0.00 session."],
             is_stderr=False,
         )
-        assert self.mod._prompt_tokens == 0
-        assert self.mod._completion_tokens == 0
+        assert self.mod._prompt_tokens == 1000
+        assert self.mod._completion_tokens == 200
 
     def test_non_token_lines_forwarded_unchanged(self):
         output = self._run_stream(["hello world", "second line"], is_stderr=False)


### PR DESCRIPTION
## Summary

Current aider versions print `Tokens: 2.7k sent, 109 received.` to **stdout**, not stderr. `_stream()` only applied `_TOKEN_RE` when `is_stderr=True`, so the regex never matched and every aider run logged `prompt=0 completion=0 total=0`.

Fix: remove the `is_stderr` guard — scan both streams. The `Tokens: X sent, Y received.` pattern is unambiguous enough that scanning stdout doesn't risk false positives.

Updated the unit test that was asserting stdout does NOT accumulate — it now correctly asserts it does.

## Test plan

- [ ] `make test` — 289 pass
- [ ] `make test-analysis BACKENDS=aider` — token counts now non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)